### PR TITLE
fix(asammdf): add compatibility with python2.x

### DIFF
--- a/asammdf/mdf.py
+++ b/asammdf/mdf.py
@@ -54,13 +54,13 @@ class MDF(object):
 
     def __setattr__(self, attr, value):
         if attr == 'file':
-            super().__setattr__(attr, value)
+            super(MDF, self).__setattr__(attr, value)
         else:
             setattr(self.file, attr, value)
 
     def __getattr__(self, attr):
         if attr == 'file':
-            return super().__getattr__(attr)
+            return super(MDF, self).__getattr__(attr)
         else:
             return getattr(self.file, attr)
 

--- a/asammdf/mdf3.py
+++ b/asammdf/mdf3.py
@@ -466,7 +466,7 @@ class MDF3(object):
         kargs = {'block_len': DG32_BLOCK_SIZE if self.version in ('3.20', '3.30') else DG31_BLOCK_SIZE}
         gp['data_group'] = DataGroup(**kargs)
 
-    def get(self, name=None, *, group=None, index=None, raster=None):
+    def get(self, name=None, group=None, index=None, raster=None):
         """Gets channel samples.
         Channel can be specified in two ways:
 
@@ -755,7 +755,7 @@ class MDF3(object):
 
         return info
 
-    def remove(self, *, group=None, name=None):
+    def remove(self, group=None, name=None):
         """Remove data group. Use *group* or *name* keyword arguments to identify the group's index. *group* has priority
 
         Parameters

--- a/asammdf/mdf4.py
+++ b/asammdf/mdf4.py
@@ -550,7 +550,7 @@ class MDF4(object):
         #data group
         gp['data_group'] = DataGroup(**{})
 
-    def get(self, name=None, *, group=None, index=None, raster=None):
+    def get(self, name=None, group=None, index=None, raster=None):
         """Gets channel samples.
         Channel can be specified in two ways:
 
@@ -875,7 +875,7 @@ class MDF4(object):
 
         return info
 
-    def remove(self, *, group=None, name=None):
+    def remove(self, group=None, name=None):
         """Remove data group. Use *group* or *name* keyword arguments to identify the group's index. *group* has priority
 
         Parameters

--- a/asammdf/v3blocks.py
+++ b/asammdf/v3blocks.py
@@ -1,6 +1,6 @@
 import time
 import os
-from struct import unpack, pack, iter_unpack
+from struct import unpack, pack
 
 from functools import partial
 
@@ -91,7 +91,7 @@ class Channel(dict):
 
     '''
     def __init__(self, **kargs):
-        super().__init__()
+        super(Channel, self).__init__()
 
         self.name = ''
 
@@ -229,7 +229,7 @@ class ChannelConversion(dict):
 
     '''
     def __init__(self, **kargs):
-        super().__init__()
+        super(ChannelConversion, self).__init__()
 
         try:
             stream = kargs['file_stream']
@@ -256,7 +256,12 @@ class ChannelConversion(dict):
                 self['formula'] = unpack('<{}s'.format(size - 46), block[CC_COMMON_BLOCK_SIZE:])[0]
 
             elif conv_type in (CONVERSION_TYPE_TABI, CONVERSION_TYPE_TABX):
-                for i, (raw, phys) in enumerate(iter_unpack('<2d', block[CC_COMMON_BLOCK_SIZE:])):
+                # iter_unpack('<2d', block[CC_COMMON_BLOCK_SIZE:])
+                blocks = []
+                for i in range(CC_COMMON_BLOCK_SIZE, len(block)):
+                    blocks.append(unpack('<2d', block[i:]))
+                # blocks = iter(blocks)
+                for i, (raw, phys) in enumerate(blocks):
                     (self['raw_{}'.format(i)],
                      self['phys_{}'.format(i)]) = raw, phys
 
@@ -286,14 +291,24 @@ class ChannelConversion(dict):
             elif conv_type == CONVERSION_TYPE_VTAB:
                 nr = self['ref_param_nr']
 
-                for i, (val, text) in enumerate(iter_unpack('<d32s', block[CC_COMMON_BLOCK_SIZE:])):
+                # iter_unpack('<d32s', block[CC_COMMON_BLOCK_SIZE:])
+                blocks = []
+                for i in range(CC_COMMON_BLOCK_SIZE, len(block)):
+                    blocks.append(unpack('<d32s', block[i:]))
+                # blocks = iter(blocks)
+                for i, (val, text) in enumerate(blocks):
                     (self['param_val_{}'.format(i)],
                      self['text_{}'.format(i)]) = val, text
 
             elif conv_type == CONVERSION_TYPE_VTABR:
                 nr = self['ref_param_nr']
 
-                for i, (lower, upper, text) in enumerate(iter_unpack('<2dI', block[CC_COMMON_BLOCK_SIZE:])):
+                # iter_unpack('<2dI', block[CC_COMMON_BLOCK_SIZE:])
+                blocks = []
+                for i in range(CC_COMMON_BLOCK_SIZE, len(block)):
+                    blocks.append(unpack('<2dI', block[i:]))
+                # blocks = iter(blocks)
+                for i, (lower, upper, text) in enumerate(blocks):
                     (self['lower_{}'.format(i)],
                      self['upper_{}'.format(i)],
                      self['text_{}'.format(i)]) = lower, upper, text
@@ -489,7 +504,7 @@ class ChannelDependency(dict):
 
     '''
     def __init__(self, **kargs):
-        super().__init__()
+        super(ChannelDependency, self).__init__()
 
         try:
             stream = kargs['file_stream']
@@ -578,7 +593,7 @@ class ChannelExtension(dict):
 
     '''
     def __init__(self, **kargs):
-        super().__init__()
+        super(ChannelExtension, self).__init__()
 
         try:
             stream = kargs['file_stream']
@@ -676,7 +691,7 @@ class ChannelGroup(dict):
 
     '''
     def __init__(self, **kargs):
-        super().__init__()
+        super(ChannelGroup, self).__init__()
 
         try:
             stream = kargs['file_stream']
@@ -753,7 +768,7 @@ class DataBlock(dict):
     """
 
     def __init__(self, **kargs):
-        super().__init__()
+        super(DataBlock, self).__init__()
 
         self.compression = kargs.get('compression', False)
 
@@ -772,17 +787,17 @@ class DataBlock(dict):
     def __setitem__(self, item, value):
         if item == 'data':
             if self.compression:
-                super().__setitem__(item, compress(value))
+                super(DataBlock, self).__setitem__(item, compress(value))
             else:
-                super().__setitem__(item, value)
+                super(DataBlock, self).__setitem__(item, value)
         else:
-            super().__setitem__(item, value)
+            super(DataBlock, self).__setitem__(item, value)
 
     def __getitem__(self, item):
         if item == 'data' and self.compression:
-            return decompress(super().__getitem__(item))
+            return decompress(super(DataBlock, self).__getitem__(item))
         else:
-            return super().__getitem__(item)
+            return super(DataBlock, self).__getitem__(item)
 
     def __bytes__(self):
         return self['data']
@@ -822,7 +837,7 @@ class DataGroup(dict):
 
     '''
     def __init__(self, **kargs):
-        super().__init__()
+        super(DataGroup, self).__init__()
 
         try:
             stream = kargs['file_stream']
@@ -901,7 +916,7 @@ class FileIdentificationBlock(dict):
 
     '''
     def __init__(self, **kargs):
-        super().__init__()
+        super(FileIdentificationBlock, self).__init__()
 
         self.address = 0
         try:
@@ -980,7 +995,7 @@ class HeaderBlock(dict):
 
     '''
     def __init__(self, **kargs):
-        super().__init__()
+        super(HeaderBlock, self).__init__()
 
         self.address = 64
         try:
@@ -1071,7 +1086,7 @@ class ProgramBlock(dict):
 
     '''
     def __init__(self, **kargs):
-        super().__init__()
+        super(ProgramBlock, self).__init__()
 
         try:
             stream = kargs['file_stream']
@@ -1118,7 +1133,7 @@ class SampleReduction(dict):
 
     '''
     def __init__(self, **kargs):
-        super().__init__()
+        super(SampleReduction, self).__init__()
 
         try:
             stream = kargs['file_stream']
@@ -1179,7 +1194,7 @@ class TextBlock(dict):
 
     '''
     def __init__(self, **kargs):
-        super().__init__()
+        super(TextBlock, self).__init__()
         try:
             stream = kargs['file_stream']
             self.address = address = kargs['address']
@@ -1255,7 +1270,7 @@ class TriggerBlock(dict):
 
     '''
     def __init__(self, **kargs):
-        super().__init__()
+        super(TriggerBlock, self).__init__()
 
         try:
             self.address = address = kargs['address']
@@ -1271,7 +1286,12 @@ class TriggerBlock(dict):
              self['text_addr'],
              self['trigger_events_nr']) = unpack('<2sHIH', block[:10])
 
-            for i, (t, pre, post) in enumerate(iter_unpack('<3d', block[10:])):
+            # iter_unpack('<3d', block[10:])
+            blocks = []
+            for i in range(10, len(block)):
+                blocks.append(unpack('<3d', block[i:]))
+            # blocks = iter(blocks)
+            for i, (t, pre, post) in enumerate(blocks):
                 (self['trigger_{}_time'.format(i)],
                  self['trigger_{}_pretime'.format(i)],
                  self['trigger_{}_posttime'.format(i)]) = t, pre, post

--- a/asammdf/v4blocks.py
+++ b/asammdf/v4blocks.py
@@ -1,7 +1,7 @@
 
 import time
 from .v4constants import *
-from struct import unpack, pack, iter_unpack, unpack_from
+from struct import unpack, pack, unpack_from
 
 from functools import partial
 
@@ -30,7 +30,7 @@ __all__ = ['Channel',
 class Channel(dict):
     """ CNBLOCK class"""
     def __init__(self, **kargs):
-        super().__init__()
+        super(Channel, self).__init__()
 
         self.name = ''
 
@@ -108,7 +108,7 @@ class Channel(dict):
 class ChannelGroup(dict):
     """CGBLOCK class"""
     def __init__(self, **kargs):
-        super().__init__()
+        super(ChannelGroup, self).__init__()
 
         try:
             self.address = address = kargs['address']
@@ -160,7 +160,7 @@ class ChannelGroup(dict):
 class ChannelConversion(dict):
     """CCBLOCK class"""
     def __init__(self, **kargs):
-        super().__init__()
+        super(ChannelConversion, self).__init__()
 
         try:
             self.address = address = kargs['address']
@@ -247,7 +247,12 @@ class ChannelConversion(dict):
                  self['val_param_nr'],
                  self['min_phy_value'],
                  self['max_phy_value']) = unpack_from('<4Q2B3H2d', block)
-                for i, (raw, phys) in enumerate(iter_unpack('<2d', block[56:])):
+                # blocks = iter_unpack('<2d', block[56:])
+                blocks = []
+                for i in range(56, len(block)):
+                    blocks.append(unpack('<2d', block[i:]))
+                # blocks = iter(blocks)
+                for i, (raw, phys) in enumerate(blocks):
                     (self['raw_{}'.format(i)],
                      self['phys_{}'.format(i)]) = raw, phys
 
@@ -263,7 +268,12 @@ class ChannelConversion(dict):
                  self['val_param_nr'],
                  self['min_phy_value'],
                  self['max_phy_value']) = unpack_from('<4Q2B3H2d', block)
-                for i, (lower, upper, phys) in enumerate(iter_unpack('<3d', block[56:-8])):
+                # blocks = iter_unpack('<3d', block[56:-8])
+                blocks = []
+                for i in range(56, len(block), -8):
+                    blocks.append(unpack('<3d', block[i:-8]))
+                # blocks = iter(blocks)
+                for i, (lower, upper, phys) in enumerate(blocks):
                     (self['lower_{}'.format(i)],
                      self['upper_{}'.format(i)],
                      self['phys_{}'.format(i)]) = lower, upper, phys
@@ -579,7 +589,7 @@ class DataBlock(dict):
 
     """
     def __init__(self, **kargs):
-        super().__init__()
+        super(DataBlock, self).__init__()
 
         self.compression = kargs.get('compression', False)
 
@@ -605,17 +615,17 @@ class DataBlock(dict):
     def __setitem__(self, item, value):
         if item == 'data':
             if self.compression:
-                super().__setitem__(item, compress(value))
+                super(DataBlock, self).__setitem__(item, compress(value))
             else:
-                super().__setitem__(item, value)
+                super(DataBlock, self).__setitem__(item, value)
         else:
-            super().__setitem__(item, value)
+            super(DataBlock, self).__setitem__(item, value)
 
     def __getitem__(self, item):
         if item == 'data' and self.compression:
-            return decompress(super().__getitem__(item))
+            return decompress(super(DataBlock, self).__getitem__(item))
         else:
-            return super().__getitem__(item)
+            return super(DataBlock, self).__getitem__(item)
 
     def __bytes__(self):
         return pack(FMT_DATA_BLOCK.format(self['block_len'] - COMMON_SIZE), *[self[key] for key in KEYS_DATA_BLOCK])
@@ -625,7 +635,7 @@ class FileIdentificationBlock(dict):
     """IDBLOCK class"""
     def __init__(self, **kargs):
 
-        super().__init__()
+        super(FileIdentificationBlock, self).__init__()
 
         self.address = 0
 
@@ -669,7 +679,7 @@ class FileIdentificationBlock(dict):
 class HeaderBlock(dict):
     """HDBLOCK class"""
     def __init__(self, **kargs):
-        super().__init__()
+        super(HeaderBlock, self).__init__()
 
         try:
             self.address = address = kargs['address']
@@ -725,7 +735,7 @@ class HeaderBlock(dict):
 class DataList(dict):
     """DLBLOCK class"""
     def __init__(self, **kargs):
-        super().__init__()
+        super(DataList, self).__init__()
 
         try:
             self.address = address = kargs['address']
@@ -776,7 +786,7 @@ class DataList(dict):
 class DataGroup(dict):
     """DGBLOCK class"""
     def __init__(self, **kargs):
-        super().__init__()
+        super(DataGroup, self).__init__()
 
         try:
             self.address = address = kargs['address']
@@ -815,7 +825,7 @@ class DataGroup(dict):
 class FileHistory(dict):
     """FHBLOCK class"""
     def __init__(self, **kargs):
-        super().__init__()
+        super(FileHistory, self).__init__()
 
         try:
             self.address = address = kargs['address']
@@ -854,7 +864,7 @@ class FileHistory(dict):
 class SourceInformation(dict):
     """SIBLOCK class"""
     def __init__(self, **kargs):
-        super().__init__()
+        super(SourceInformation, self).__init__()
 
         try:
             self.address = address = kargs['address']
@@ -894,7 +904,7 @@ class SourceInformation(dict):
 class TextBlock(dict):
     """common TXBLOCK and MDBLOCK class"""
     def __init__(self, **kargs):
-        super().__init__()
+        super(TextBlock, self).__init__()
 
         try:
             stream = kargs['file_stream']


### PR DESCRIPTION
Hi Daniel,

I thought it would be nice to make your module compatible with Python 2.7.
So I did a few changes and it seems to work now but could you make some test and review my changes?
I suggest you create a develop branch on your repository, to keep the master branch clean. The master branch would be only used for release.

Changes:
- Removed the * you have in your get and remove functions. Why are you using this?
- Replaced every super() with super(\<ClassName\>, self) for backward compatibility with Python2.7
- Replaced every iter_unpack with unpack in a loop (not sure if it works!!)

Cheers, Julien
