### PR TITLE
Use numpy.where for signed non-byte-sized integers

### DIFF
--- a/asammdf/mdf_v4.py
+++ b/asammdf/mdf_v4.py
@@ -48,6 +48,7 @@ from . import v4_constants as v4c
 from .signal import Signal
 from .utils import (
     MdfException,
+    as_non_byte_sized_signed_int,
     fix_dtype_fields,
     fmt_to_datatype_v4,
     get_fmt_v4,
@@ -3348,25 +3349,8 @@ class MDF4(object):
                                 vals = vals & mask
 
                             if data_type in v4c.SIGNED_INT:
+                                vals = as_non_byte_sized_signed_int(vals, bits)
 
-                                size = vals.dtype.itemsize
-
-                                masks = ones(
-                                    cycles_nr,
-                                    dtype=dtype('<u{}'.format(size)),
-                                )
-
-                                masks *= (1 << bits) - 1
-                                masks = ~masks
-
-                                masks *= ((vals & (1 << (bits - 1))) >> (bits - 1)).astype(dtype('<u{}'.format(size)))
-
-                                vals |= masks
-
-                                vals = vals.astype(
-                                    '<i{}'.format(size),
-                                    copy=False,
-                                )
                 else:
                     vals = self._get_not_byte_aligned_data(data, grp, ch_nr)
 


### PR DESCRIPTION
The MDF3.get method was in master was masking irrelevant bits from
non-byte-sized integers and then relying on numpy.ndarray.astype to convert
back to signed. Since numpy only has byte-sized data types, this
meant that the wrong two's complement was used (e.g. 2**16 rather than
2**14 for a 14-bit integer encoded in a np.uint16).

This change computes two's complement for non-byte-sized signed integers
using numpy.where.