### PR TITLE
Correct two's complement for non-byte-aligned data

### DIFF
--- a/asammdf/mdf_v3.py
+++ b/asammdf/mdf_v3.py
@@ -458,7 +458,10 @@ class MDF3(object):
 
         vals = fromstring(vals, dtype=dtype(types))
 
-        return vals['vals']
+        if channel['data_type'] in v23c.SIGNED_INT:
+            return as_non_byte_sized_signed_int(vals['vals'], bit_count)
+        else:
+            return vals['vals']
 
     def _validate_channel_selection(self, name=None, group=None, index=None):
         """Gets channel comment.

--- a/asammdf/mdf_v4.py
+++ b/asammdf/mdf_v4.py
@@ -1189,7 +1189,10 @@ class MDF4(object):
 
         vals = fromstring(vals, dtype=dtype(types))
 
-        return vals['vals']
+        if channel['data_type'] in v4c.SIGNED_INT:
+            return as_non_byte_sized_signed_int(vals['vals'], bit_count)
+        else:
+            return vals['vals']
 
     def _validate_channel_selection(self, name=None, group=None, index=None):
         """Gets channel comment.


### PR DESCRIPTION
Use utils.as_non_byte_sized_signed_int() for signed integer types
in _get_non_byte_aligned_data() as well.