### PR TITLE
v3 channel block long name bugfix

### DIFF
--- a/asammdf/v2_v3_blocks.py
+++ b/asammdf/v2_v3_blocks.py
@@ -350,7 +350,7 @@ class Channel(dict):
         key = 'long_name_addr'
         text = self.name
         if key in self:
-            if len(text) > 127:
+            if len(text) > 31:
                 if text in defined_texts:
                     self[key] = defined_texts[text]
                 else:
@@ -362,7 +362,7 @@ class Channel(dict):
                     blocks.append(tx_block)
             else:
                 self[key] = 0
-        self['short_name'] = '{:\0<128}'.format(text[:127]).encode('latin-1')
+        self['short_name'] = '{:\0<32}'.format(text[:31]).encode('latin-1')
 
         key = 'display_name_addr'
         text = self.display_name
@@ -426,7 +426,7 @@ class Channel(dict):
         key = 'long_name_addr'
         text = self.name
         if key in self:
-            if len(text) > 127:
+            if len(text) > 31:
                 if text in defined_texts:
                     self[key] = defined_texts[text]
                 else:
@@ -438,7 +438,7 @@ class Channel(dict):
                     stream.write(bytes(tx_block))
             else:
                 self[key] = 0
-        self['short_name'] = '{:\0<128}'.format(text[:127]).encode('latin-1')
+        self['short_name'] = '{:\0<32}'.format(text[:31]).encode('latin-1')
 
         key = 'display_name_addr'
         text = self.display_name


### PR DESCRIPTION
the maximum length of Channel's short name is 32 chars with \0 terminate. for signal name longer than 31 chars, the complete name should contained in the TXBLOCK referenced by field "long_name".