### PR TITLE
fix MDF.save comment address missing

### DIFF
--- a/asammdf/mdf_v3.py
+++ b/asammdf/mdf_v3.py
@@ -3239,6 +3239,7 @@ class MDF3(object):
 
             comment = TextBlock(text=self.header.comment)
             write(bytes(comment))
+            self.header['comment_addr'] = address
             address += comment['block_len']
 
             # DataGroup


### PR DESCRIPTION
mdf_v3 save_with_metadata lost header block's comment address.