### PR TITLE
Minor README.md fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
-<img align=left src="https://raw.githubusercontent.com/danielhrisca/asammdf/master/asammdf.png" width="192" height="192" /> 
+<img align=left src="https://raw.githubusercontent.com/danielhrisca/asammdf/master/asammdf.png" width="192" height="192" />
 
 <p align=center>
-   
-*asammdf* is a fast parser and editor for ASAM (Associtation for Standardisation of Automation and Measuring Systems) MDF (Measurement Data Format) files. 
 
-*asammdf* supports MDF versions 2 (.dat), 3 (.mdf) and 4 (.mf4). 
+*asammdf* is a fast parser and editor for ASAM (Associtation for Standardisation of Automation and Measuring Systems) MDF (Measurement Data Format) files.
+
+*asammdf* supports MDF versions 2 (.dat), 3 (.mdf) and 4 (.mf4).
 
 *asammdf* works on Python 2.7, and Python >= 3.4
 
@@ -13,19 +13,19 @@
 
 </p>
 
-<img align=left src="https://raw.githubusercontent.com/danielhrisca/asammdf/development/gui.png"/> 
+<img align=left src="https://raw.githubusercontent.com/danielhrisca/asammdf/development/gui.png"/>
 
 
 # Status
 
-! | Travis CI  | Coverage  |  Codacy  | ReadTheDocs 
+! | Travis CI  | Coverage  |  Codacy  | ReadTheDocs
 --|--|--|--|--
-master | [![Build Status](https://travis-ci.org/danielhrisca/asammdf.svg?branch=master)](https://travis-ci.org/danielhrisca/asammdf) | [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/a3da21da90ca43a5b72fc24b56880c99?branch=master)](https://www.codacy.com/app/danielhrisca/asammdf?utm_source=github.com&utm_medium=referral&utm_content=danielhrisca/asammdf&utm_campaign=Badge_Coverage) | [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a3da21da90ca43a5b72fc24b56880c99?branch=master)](https://www.codacy.com/app/danielhrisca/asammdf?utm_source=github.com&utm_medium=referral&utm_content=danielhrisca/asammdf&utm_campaign=badger) |  [![Documentation Status](http://readthedocs.org/projects/asammdf/badge/?version=master)](http://asammdf.readthedocs.io/en/master/?badge=stable) |  
-development| [![Build Status](https://travis-ci.org/danielhrisca/asammdf.svg?branch=development)](https://travis-ci.org/danielhrisca/asammdf) | [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/a3da21da90ca43a5b72fc24b56880c99?branch=development)](https://www.codacy.com/app/danielhrisca/asammdf?utm_source=github.com&utm_medium=referral&utm_content=danielhrisca/asammdf&utm_campaign=Badge_Coverage) | [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a3da21da90ca43a5b72fc24b56880c99?branch=development)](https://www.codacy.com/app/danielhrisca/asammdf?utm_source=github.com&utm_medium=referral&utm_content=danielhrisca/asammdf&utm_campaign=badger) | [![Documentation Status](http://readthedocs.org/projects/asammdf/badge/?version=development)](http://asammdf.readthedocs.io/en/development/?badge=stable) |   
+master | [![Build Status](https://travis-ci.org/danielhrisca/asammdf.svg?branch=master)](https://travis-ci.org/danielhrisca/asammdf) | [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/a3da21da90ca43a5b72fc24b56880c99?branch=master)](https://www.codacy.com/app/danielhrisca/asammdf?utm_source=github.com&utm_medium=referral&utm_content=danielhrisca/asammdf&utm_campaign=Badge_Coverage) | [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a3da21da90ca43a5b72fc24b56880c99?branch=master)](https://www.codacy.com/app/danielhrisca/asammdf?utm_source=github.com&utm_medium=referral&utm_content=danielhrisca/asammdf&utm_campaign=badger) |  [![Documentation Status](http://readthedocs.org/projects/asammdf/badge/?version=master)](http://asammdf.readthedocs.io/en/master/?badge=stable) |
+development| [![Build Status](https://travis-ci.org/danielhrisca/asammdf.svg?branch=development)](https://travis-ci.org/danielhrisca/asammdf) | [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/a3da21da90ca43a5b72fc24b56880c99?branch=development)](https://www.codacy.com/app/danielhrisca/asammdf?utm_source=github.com&utm_medium=referral&utm_content=danielhrisca/asammdf&utm_campaign=Badge_Coverage) | [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a3da21da90ca43a5b72fc24b56880c99?branch=development)](https://www.codacy.com/app/danielhrisca/asammdf?utm_source=github.com&utm_medium=referral&utm_content=danielhrisca/asammdf&utm_campaign=badger) | [![Documentation Status](http://readthedocs.org/projects/asammdf/badge/?version=development)](http://asammdf.readthedocs.io/en/development/?badge=stable) |
 
 PyPI| conda-forge
 --|--
-[![PyPI version](https://badge.fury.io/py/asammdf.svg)](https://badge.fury.io/py/asammdf)  | [![conda-forge version](https://anaconda.org/conda-forge/asammdf/badges/version.svg)](https://anaconda.org/conda-forge/asammdf) 
+[![PyPI version](https://badge.fury.io/py/asammdf.svg)](https://badge.fury.io/py/asammdf)  | [![conda-forge version](https://anaconda.org/conda-forge/asammdf/badges/version.svg)](https://anaconda.org/conda-forge/asammdf)
 
 
 # Project goals
@@ -54,11 +54,11 @@ The main goals for this library are:
     * mdf version 3 channels with CDBLOCK
     * mdf version 4 structure channel composition
     * mdf version 4 channel arrays with CNTemplate storage and one of the array types:
-    
+
         * 0 - array
         * 1 - scaling axis
         * 2 - look-up
-        
+
 * add and extract attachments for mdf version 4
 * handle large files (for example merging two fileas, each with 14000 channels and 5GB size, on a RaspberryPi) using *memory* = *minimum* argument
 * extract channel data, master channel and extra channel information as *Signal* objects for unified operations with v3 and v4 files
@@ -67,7 +67,7 @@ The main goals for this library are:
     * Pandas data frames are good if all the channels have the same time based
     * a measurement will usually have channels from different sources at different rates
     * the *Signal* class facilitates operations with such channels
-    
+
  * graphical interface to visualize channels and perform operations with the files
 
 # Major features not implemented (yet)
@@ -75,7 +75,7 @@ The main goals for this library are:
 * for version 3
 
     * functionality related to sample reduction block: the samples reduction blocks are simply ignored
-    
+
 * for version 4
 
     * functionality related to sample reduction block: the samples reduction blocks are simply ignored
@@ -86,7 +86,7 @@ The main goals for this library are:
       but no further steps are taken to sanitize the measurement
     * full support for remaining mdf 4 channel arrays types
     * xml schema for MDBLOCK: most metadata stored in the comment blocks will not be available
-    * full handling of event blocks: events are transfered to the new files (in case of calling methods 
+    * full handling of event blocks: events are transfered to the new files (in case of calling methods
       that return new *MDF* objects) but no new events can be created
     * channels with default X axis: the defaukt X axis is ignored and the channel group's master channel
       is used
@@ -94,26 +94,25 @@ The main goals for this library are:
 # Usage
 
 ```python
-   from asammdf import MDF
-   
-   mdf = MDF('sample.mdf')
-   speed = mdf.get('WheelSpeed')
-   speed.plot()
-   
-   important_signals = ['WheelSpeed', 'VehicleSpeed', 'VehicleAcceleration']
-   # get short measurement with a subset of channels from 10s to 12s 
-   short = mdf.filter(important_signals).cut(start=10, stop=12)
-   
-   # convert to version 4.10 and save to disk
-   short.convert('4.10').save('important signals.mf4')
-   
-   # plot some channels from a huge file
-   efficient = MDF('huge.mf4', , memory='minimum')
-   for signal in efficient.select(['Sensor1', 'Voltage3']):
-       signal.plot()
-   
-```  
- 
+from asammdf import MDF
+
+mdf = MDF('sample.mdf')
+speed = mdf.get('WheelSpeed')
+speed.plot()
+
+important_signals = ['WheelSpeed', 'VehicleSpeed', 'VehicleAcceleration']
+# get short measurement with a subset of channels from 10s to 12s
+short = mdf.filter(important_signals).cut(start=10, stop=12)
+
+# convert to version 4.10 and save to disk
+short.convert('4.10').save('important signals.mf4')
+
+# plot some channels from a huge file
+efficient = MDF('huge.mf4', , memory='minimum')
+for signal in efficient.select(['Sensor1', 'Voltage3']):
+   signal.plot()
+```
+
 Check the *examples* folder for extended usage demo, or the documentation
 http://asammdf.readthedocs.io/en/master/examples.html
 
@@ -121,7 +120,7 @@ http://asammdf.readthedocs.io/en/master/examples.html
 http://asammdf.readthedocs.io/en/master
 
 # Contributing
-Please have a look over the [contributing guidelines](https://github.com/danielhrisca/asammdf/blob/develoment/CONTRIBUTING.md)
+Please have a look over the [contributing guidelines](CONTRIBUTING.md)
 
 ## Contributors
 Thanks to all who contributed with commits to *asammdf*:
@@ -136,18 +135,18 @@ Thanks to all who contributed with commits to *asammdf*:
 * venden [venden](https://github.com/venden)
 
 # Installation
-*asammdf* is available on 
+*asammdf* is available on
 
 * github: https://github.com/danielhrisca/asammdf/
 * PyPI: https://pypi.org/project/asammdf/
 * conda-forge: https://anaconda.org/conda-forge/asammdf
-    
+
+```shell
+pip install asammdf
+# or for anaconda
+conda install -c conda-forge asammdf
 ```
-   pip install asammdf
-   # or for anaconda
-   conda install -c conda-forge asammdf 
-```
-    
+
 # Dependencies
 asammdf uses the following libraries
 
@@ -175,4 +174,3 @@ other optional dependencies
 # Benchmarks
 
 http://asammdf.readthedocs.io/en/develoment/benchmarks.html
-


### PR DESCRIPTION
- Fixed link to CONTRIBUTING.md
- Stripped trailing white space.
- Removed preceding white-space in the example usage so that the code can be copy and pasted without an extra indent.