### PR TITLE
improve documentation, mostly fixing typos

### DIFF
--- a/documentation/benchmarks.rst
+++ b/documentation/benchmarks.rst
@@ -28,14 +28,14 @@ so for best performance it is advised to use Python >= 3.6.
 Test setup
 ==========
 
-The benchmarks were done using two test files (available here https://github.com/danielhrisca/asammdf/issues/14) (for mdf version 3 and 4) of around 170MB.
+The benchmarks were done using two test files (available `here <https://github.com/danielhrisca/asammdf/issues/14>`_) (for mdf version 3 and 4) of around 170MB.
 The files contain 183 data groups and a total of 36424 channels.
 
 *asamdf 4.0.0.dev* was compared against *mdfreader 2.7.8*.
 *mdfreader* seems to be the most used Python package to handle MDF files, and it also supports both version 3 and 4 of the standard.
 
-The three benchmark cathegories are file open, file save and extracting the data for all channels inside the file(36424 calls).
-For each cathegory two aspect were noted: elapsed time and peak RAM usage.
+The three benchmark categories are file open, file save and extracting the data for all channels inside the file (36424 calls).
+For each category two aspect were noted: elapsed time and peak RAM usage.
 
 Dependencies
 ------------

--- a/documentation/buslogging.rst
+++ b/documentation/buslogging.rst
@@ -2,15 +2,15 @@
 Bus logging
 ------------
 
-Initial read only mode for mdf version 4.10 files containg CAN bus logging
+Initial read only mode for mdf version 4.10 files containing CAN bus logging
 is now implemented.
 
-To handle this, **canmatrix** package was added to the dependecies; you will need to install the latest code
+To handle this, the **canmatrix** package was added to the dependencies; you will need to install the latest code
 from the **canmatrix** development branch.
 
 Let's take for example the following situation: the .dbc contains the definition
-for the CAN message called "VehicleStatus" with ID=123. This message contains the
-signal "EngineStatus". Logging was made from the CAN bus with ID=1 (CAN1).
+for the CAN message called "VehicleStatus" with `ID=123`. This message contains the
+signal "EngineStatus". Logging was made from the CAN bus with `ID=1` (CAN1).
 
 There multiple ways to address this channel in this situation:
 

--- a/documentation/gui.rst
+++ b/documentation/gui.rst
@@ -22,7 +22,7 @@
 GUI
 ---
 
-Starting with version 3.4.0 there is a graphical user interface that comes together with *asammdf*. 
+Starting with version `3.4.0` there is a graphical user interface that comes together with *asammdf*.
 
 With the GUI tool you can
 
@@ -30,7 +30,7 @@ With the GUI tool you can
 * see channel, conversion and source metadata as stored in the MDF file
 * access library functionality for single files (convert, export, cut, filter, resample) and multiple files (concatenate, stack)
 
-After you pip install asammdf there will be a new script called *asammdf.exe* in the ````python_installation_folder\Scripts```` folder.
+After you pip install asammdf there will be a new script called *asammdf.exe* in the `python_installation_folder\\Scripts` folder.
 
 The following dependencies are required by the GUI
 
@@ -57,7 +57,7 @@ The following settings are available
       * ``low``
       * ``minimum``
       
-  Changing this option does not affect already opened files; it will only apply later when openeing a new file.
+  Changing this option does not affect already opened files; it will only apply later when opening a new file.
   
 * **Plot lines**: controls the visual style of the channels plot lines:
 
@@ -77,7 +77,7 @@ The following settings are available
       
 .. note::
 
-    * Changing the *Memory* option does not affect already opened files; it will only apply later when openeing a new file.
+    * Changing the *Memory* option does not affect already opened files; it will only apply later when opening a new file.
       
 Plot
 ----
@@ -98,15 +98,15 @@ R        Range             Display a movable range that will trigger the display
 S        Stack             Y Stack all active channels so that they don't overlap, keeping the X-axis range
 ←        Move cursor left  Moves the cursor to the next sample on the left
 →        Move cursor right Moves the cursor to the next sample on the right
-Ctrl+B   Bin               Toggle binary reprezentation of integer channels
-Ctrl+H   Hex               Toggle hex reprezentation of integer channels
-Ctrl+P   Physical          Toggle physical reprezentation of integer channels
+Ctrl+B   Bin               Toggle binary representation of integer channels
+Ctrl+H   Hex               Toggle hex representation of integer channels
+Ctrl+P   Physical          Toggle physical representation of integer channels
 ======== ================= ================================================================================================================
 
 
 .. rubric:: Footnotes
 
-.. [#f1] If the cursor is prezent the zooming will center on it.
+.. [#f1] If the cursor is present the zooming will center on it.
 
 
 Single files
@@ -134,9 +134,9 @@ There is no restriction, so the same file can be opened several times.
 
 Quick channel search field for the current file
 -----------------------------------------------
-Using the *Seetings->Searh* menu option the user can choose how the search is performed. A positive search match will scroll the channels tree and highlight the channel entry. 
+Using the *Settings->Search* menu option the user can choose how the search is performed. A positive search match will scroll the channels tree and highlight the channel entry.
 
-When the same channel name exist several times in the file, you can switch between the occurences using the arrow buttons.
+When the same channel name exist several times in the file, you can switch between the occurrences using the arrow buttons.
 
 Complete channels tree
 ----------------------
@@ -146,7 +146,7 @@ Double clicking a channel name will display a pop-up window with the channel inf
 
 .. image:: images/channel_info.png
    
-Only the channels that are checked in the channels tree will pe selected for plotting when the *Plot* button willbe pressed. 
+Only the channels that are checked in the channels tree will be selected for plotting when the *Plot* button is pressed.
 Checking or unchecking channels will not affect the current plot.
 
 Command buttons
@@ -184,7 +184,7 @@ Each item has four elements
 4. channel value label 
 
     * the value is only displayed if the cursor or range are active. For the cursor is will show the current value, and for the range it will
-      shwo the value delta between the range start and stop timestamps
+      show the value delta between the range start and stop timestamps
       
 Double clicking an item will open a range editor dialog
 
@@ -205,7 +205,7 @@ Selecting items from the *Selected channels list* will enable the Y-axis
 
 .. image:: images/graph_axis.png
 
-Using the *C* keyboard shotcut will toggle the cursor, and with it the channel values will be displayed for each item in the *Selected channels list*
+Using the *C* keyboard shortcut will toggle the cursor, and with it the channel values will be displayed for each item in the *Selected channels list*
 
 .. image:: images/cursor_phys.png
 
@@ -217,7 +217,7 @@ The *Ctrl+H* and *Ctrl+B* keyboard shortcuts will
 .. image:: images/cursor_hex.png
 .. image:: images/cursor_bin.png
 
-Using the *R* keyboard shotcut will toggle the range, and with it the channel values will be displayed for each item in the *Selected channels list*. When the range is
+Using the *R* keyboard shortcut will toggle the range, and with it the channel values will be displayed for each item in the *Selected channels list*. When the range is
 enabled, using the *H* keyboard shortcut will not home to the whole time range, but instead will use the range time interval. 
 
 .. image:: images/range.png
@@ -232,7 +232,7 @@ The *Multiple files* toolbox page is used to concatenate or stack multiple files
 
 .. image:: images/multiple_files.png
 
-The files list can be rearanged in the list (1) by drag and dropping lines. Unwanted files can be deleted by 
+The files list can be rearranged in the list (1) by drag and dropping lines. Unwanted files can be deleted by
 selecting them and pressing the *DEL* key. The files order is considered from top to bottom. 
 
 

--- a/documentation/intro.rst
+++ b/documentation/intro.rst
@@ -39,7 +39,7 @@ Features
 * extract channel data, master channel and extra channel information as *Signal* objects for unified operations with v3 and v4 files
 * time domain operation using the *Signal* class
 
-    * Pandas data frames are good if all the channels have the same time based
+    * Pandas data frames are good if all the channels have the same time base
     * a measurement will usually have channels from different sources at different rates
     * the *Signal* class facilitates operations with such channels
 
@@ -48,11 +48,11 @@ Major features not implemented (yet)
 
 * for version 3
 
-    * functionality related to sample reduction block: the samples reduction blocks are simply ignored
-    
+    * functionality related to sample reduction block: the sample reduction blocks are simply ignored
+
 * for version 4
 
-    * functionality related to sample reduction block: the samples reduction blocks are simply ignored
+    * functionality related to sample reduction block: the sample reduction blocks are simply ignored
     * handling of channel hierarchy: channel hierarchy is ignored
     * full handling of bus logging measurements: currently only CAN bus logging is implemented with the
       ability to *get* signals defined in the attached CAN database (.arxml or .dbc)
@@ -60,16 +60,16 @@ Major features not implemented (yet)
       but no further steps are taken to sanitize the measurement
     * full support for remaining mdf 4 channel arrays types
     * xml schema for MDBLOCK: most metadata stored in the comment blocks will not be available
-    * full handling of event blocks: events are transfered to the new files (in case of calling methods 
+    * full handling of event blocks: events are transferred to the new files (in case of calling methods
       that return new *MDF* objects) but no new events can be created
-    * channels with default X axis: the defaukt X axis is ignored and the channel group's master channel
+    * channels with default X axis: the default X axis is ignored and the channel group's master channel
       is used
-    
-    
+
+
 Dependencies
 ============
 asammdf uses the following libraries
-    
+
 * numpy : the heart that makes all tick
 * numexpr : for algebraic and rational channel conversions
 * matplotlib : for Signal plotting
@@ -94,21 +94,21 @@ other optional dependencies
 
 Installation
 ============
-*asammdf* is available on 
+*asammdf* is available on
 
     * github: https://github.com/danielhrisca/asammdf/
     * PyPI: https://pypi.org/project/asammdf/
     * conda-forge: https://anaconda.org/conda-forge/asammdf
-    
-    .. code-block: python
+
+    .. code:: python
 
        pip install asammdf
        # or for anaconda
        conda install -c conda-forge asammdf
-       
+
 Contributing
 ============
-Please have a look over the [contributing guidelines](https://github.com/danielhrisca/asammdf/blob/master/CONTRIBUTING.md)
+Please have a look over the `contributing guidelines <https://github.com/danielhrisca/asammdf/blob/master/CONTRIBUTING.md>`_
 
 Contributors
 ------------

--- a/documentation/tips.rst
+++ b/documentation/tips.rst
@@ -44,7 +44,7 @@ Disadvantages
 
 * higher RAM usage, there is the chance of MemoryError for large files
 * data is not accessed in chunks 
-* time can be wasted if only a small number of channels is retreived from the file (for example *filter*, *get* or *select* methods)
+* time can be wasted if only a small number of channels is retrieved from the file (for example *filter*, *get* or *select* methods)
 
 Use case
 
@@ -73,7 +73,7 @@ Use case
 
 * when 'full' data exceeds available RAM
 * it is advised to avoid getting individual channels when using this option
-* best performance / memory usage ratio when using *cut*, *convert*, *flter*, *merge* or *select* methods
+* best performance / memory usage ratio when using *cut*, *convert*, *filter*, *merge* or *select* methods
 
 .. note::
 
@@ -85,12 +85,12 @@ Use case
 Advantages
 
 * lowest RAM usage
-* the only choise when dealing with huge files (10's of thousands of channels and GB of sample data)
+* the only choice when dealing with huge files (10's of thousands of channels and GB of sample data)
 * handle big files on 32 bit Python ()
 
 Disadvantages
 
-* slightly slower performance compared to momeory='low'
+* slightly slower performance compared to memory='low'
 * must call *close* method to release the temporary file used in case of appending.
 
 .. note::
@@ -123,7 +123,7 @@ Faster file loading
 
 BytesIO and *memory='full'*
 ---------------------------
-In case of files with high block count (large number of channels, or large number of data blocks) you cand speed up the 
+In case of files with high block count (large number of channels, or large number of data blocks) you can speed up the
 loading in case of *full* memory option, at the expense of higher RAM usage by reading the file into a *BytesIO* object
 and feeding it to the *MDF* class
 
@@ -150,7 +150,7 @@ Skip XML parsing for MDF4 files
 -------------------------------
 MDF4 uses the XML channel comment to define the channel's display name (this acts
 as an alias for the channel name). XML pasring is an expensive operation that can
-have a big impact on the loading performance of measurements with hihg channel  
+have a big impact on the loading performance of measurements with high channel
 count. 
 
 You can use the keyword only argument *use_display_names* when creating MDF


### PR DESCRIPTION
Hi Daniel,

I finally found the time to read through the whole documentation and while doing this, I made some small changes. Most of them are just correcting typos. Some others are fixing `REst` format (e.g. for links).