### PR TITLE
Bugfix: Re-read dtype format information for unaligned data.

### DIFF
--- a/asammdf/blocks/mdf_v4.py
+++ b/asammdf/blocks/mdf_v4.py
@@ -2252,7 +2252,7 @@ class MDF4(object):
         vals = vals.tostring()
 
         channel.dtype_fmt = get_fmt_v4(channel["data_type"], bit_count)
-        
+
         fmt = channel.dtype_fmt
         if size <= byte_count:
             if channel["data_type"] in big_endian_types:

--- a/asammdf/blocks/mdf_v4.py
+++ b/asammdf/blocks/mdf_v4.py
@@ -2251,8 +2251,8 @@ class MDF4(object):
 
         vals = vals.tostring()
 
-        if not channel.dtype_fmt:
-            channel.dtype_fmt = get_fmt_v4(channel["data_type"], bit_count)
+        channel.dtype_fmt = get_fmt_v4(channel["data_type"], bit_count)
+        
         fmt = channel.dtype_fmt
         if size <= byte_count:
             if channel["data_type"] in big_endian_types:


### PR DESCRIPTION
If we do not reread dtype_format we get format information saved in channel previously which is based on aligned data (e.g. the  current code did not work because `byte_offset=11`, `bit_offset=7`, `bit_count=2`, the channel assumed `dtype_fmt = ">u2"` instead of `dtype_fmt = ">u2"`).