### PR TITLE
cease explicit propagation of unhandled key combinations to parents

### DIFF
--- a/asammdf/gui/widgets/plot.py
+++ b/asammdf/gui/widgets/plot.py
@@ -496,7 +496,7 @@ class Plot(QtWidgets.QWidget):
         elif (key, modifiers) in self.plot.keyboard_events:
             self.plot.keyPressEvent(event)
         else:
-            self.parent().keyPressEvent(event)
+            event.ignore()
 
     def range_removed(self):
         for i in range(self.channel_selection.count()):


### PR DESCRIPTION
Pressing modifier keys [ctrl, alt] with the plot window open was causing the
following error to appear as a pop-up:
```
no access to protected functions or signals for objects not created from Python
File "/home/njames/repos/asammdf/asammdf/gui/widgets/plot.py", line 499, in keyPressEvent self.parent().keyPressEvent(event)
```

The Qt documentation [suggests](https://doc.qt.io/qt-5/qevent.html#ignore) calling QEvent::ignore() on unhandled keyPressEvents to pass them on to parent widgets.