### PR TITLE
fix offsets in mdf4 structures with non-byte members

### DIFF
--- a/asammdf/blocks/mdf_v4.py
+++ b/asammdf/blocks/mdf_v4.py
@@ -4929,7 +4929,7 @@ class MDF4(object):
             if sig_type in (v4c.SIGNAL_TYPE_SCALAR, v4c.SIGNAL_TYPE_STRING):
 
                 s_type, s_size = fmt_to_datatype_v4(samples.dtype, samples.shape)
-                byte_size = s_size // 8
+                byte_size = s_size // 8 or 1
 
                 fields.append(samples)
                 types.append((field_name, samples.dtype, samples.shape[1:]))
@@ -5359,7 +5359,7 @@ class MDF4(object):
             if sig_type in (v4c.SIGNAL_TYPE_SCALAR, v4c.SIGNAL_TYPE_STRING):
 
                 s_type, s_size = fmt_to_datatype_v4(samples.dtype, samples.shape)
-                byte_size = s_size // 8
+                byte_size = s_size // 8 or 1
 
                 fields.append(samples)
                 types.append((field_name, samples.dtype, samples.shape[1:]))


### PR DESCRIPTION
When generating signals for a structure, the designated size in bytes of
an element is continuously accumulated to calculate the offsets of
all elements. When an element does not have a size that is a multiple
of 8 (e.g., a boolean flag), the byte size was calculated to be zero,
which means that the subsequent channel erroneously received the same
offset. Fix by rounding up the byte size.