### PR TITLE
Added workaround for FSSpec objects. Allows direct S3, Azure Datalake, etc loading.

### DIFF
--- a/asammdf/blocks/utils.py
+++ b/asammdf/blocks/utils.py
@@ -1777,9 +1777,19 @@ def all_blocks_addresses(obj):
     except:
         pass
 
-    return [
-         match.start()
-         for match in re.finditer(pattern, obj)
-    ]
+    try:
+        match_starts = [
+            match.start()
+            for match in re.finditer(pattern, obj)
+        ]
+    except TypeError:
+        """ TypeError: expected string or bytes-like object when reading
+        PyFilesystem concrete class from S3.
+        """
+        match_starts = [
+            match.start()
+            for match in re.finditer(pattern, obj.read())
+        ]
+    return match_starts
 
 


### PR DESCRIPTION
> Filesystem Spec is a project to unify various projects and classes to work with remote filesystems and file-system-like abstractions using a standard pythonic interface.

Some Anaconda articles on ```fsspec```:

- [Accessing Remote Data with a Generalized File System](https://www.anaconda.com/accessing-remote-data-generalized-file-system/)
- [Introducing Remote Content Caching with FSSpec ](https://www.anaconda.com/fsspec-remote-caching/)

Passing the object in to ```MDF()``` "is_file_like" returns True.

However the regex to find the start fails, they need to be read() as shown here:

https://github.com/SimulinkDevOps/Jupyter_MDF_Analysis/blob/4acf05b70e2bd6688113445261e8e77601666cae/22_S3_direct_loading.ipynb

With this fix you can load S3 files directly (and all other PyFilesystem objects)

https://github.com/SimulinkDevOps/Jupyter_MDF_Analysis/blob/787eae352a2271fc5597a1023449d68446e86555/22_Direct_Loading_from_S3.ipynb

https://github.com/SimulinkDevOps/Jupyter_MDF_Analysis/blob/development/quarantine/23_S3_Loading_with_caching.ipynb