### PR TITLE
add raw argument to mdf_v4.py

### DIFF
--- a/asammdf/blocks/mdf_v4.py
+++ b/asammdf/blocks/mdf_v4.py
@@ -8108,7 +8108,7 @@ class MDF4(object):
         else:
             invalidation_bits = None
 
-        vals = extract_can_signal(signal, vals)
+        vals = extract_can_signal(signal, vals, raw)
 
         comment = signal.comment or ""
 


### PR DESCRIPTION
add raw argument to "get_can_signal" funktion, in mdf_v4.py file, default value is False