### PR TITLE
Fix 'str' object has no attribute 'write_bytes'

### DIFF
--- a/asammdf/blocks/v4_blocks.py
+++ b/asammdf/blocks/v4_blocks.py
@@ -216,7 +216,7 @@ class AttachmentBlock:
 
             else:
                 self.file_name = str(file_name)
-                self.file_name.write_bytes(data)
+                file_name.write_bytes(data)
                 embedded_size = 0
                 data = b""
 


### PR DESCRIPTION
While trying to merge multiple MF4 files together using the 'stack' function, the following error was thrown

```
INFO:__main__:MF4 stacking
Traceback (most recent call last):
  File "C:\Users\james\.conda\envs\asammdf-env\lib\site-packages\asammdf\blocks\v4_blocks.py", line 140, in __init__
    self.address = address = kwargs["address"]
KeyError: 'address'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:/tools/mdf_merger.py", line 82, in <module>
    mdf = MDF.stack(path, sync=False)
  File "C:\Users\james\.conda\envs\asammdf-env\lib\site-packages\asammdf\mdf.py", line 1917, in stack
    signals, source_info, common_timebase=True
  File "C:\Users\james\.conda\envs\asammdf-env\lib\site-packages\asammdf\blocks\mdf_v4.py", line 2721, in append
    at_data, at_name, hash_sum, mime="video/avi", embedded=False
  File "C:\Users\james\.conda\envs\asammdf-env\lib\site-packages\asammdf\blocks\mdf_v4.py", line 5710, in attach
    file_name=file_name,
  File "C:\Users\james\.conda\envs\asammdf-env\lib\site-packages\asammdf\blocks\v4_blocks.py", line 219, in __init__
    self.file_name.write_bytes(data)
AttributeError: 'str' object has no attribute 'write_bytes'
```

Looking into the code, we see

```python
file_name = Path(kwargs.get("file_name", None) or "bin.bin")
# Other code...
self.file_name = str(file_name)
self.file_name.write_bytes(data)
```

The `write_byes` function is a member of the original `Path` object, not `str` object. This PR fixes it by simply removing the `self.` prefix so it uses the `Path` object instead.
