### PR TITLE
add dbs argument to extract_can_logging

### DIFF
--- a/asammdf/mdf.py
+++ b/asammdf/mdf.py
@@ -3591,6 +3591,7 @@ class MDF:
     def extract_can_logging(
         self,
         dbc_files,
+        dbs=(),
         version=None,
         ignore_invalid_signals=False,
         consolidated_j1939=True,
@@ -3602,6 +3603,8 @@ class MDF:
         ----------
         dbc_files : iterable
             iterable of str or pathlib.Path objects
+        dbs : iterable
+            iterable of (canmatrix.CanMatrix, str) tuples
         version (None) : str
             output file version
         ignore_invalid_signals (False) : bool
@@ -3640,7 +3643,7 @@ class MDF:
 
         max_flags = []
 
-        valid_dbc_files = []
+        valid_dbc_files = list(dbs)
         for dbc_name in dbc_files:
             dbc = load_can_database(dbc_name)
             if dbc is None:

--- a/test/test_CAN_bus_loogging.py
+++ b/test/test_CAN_bus_loogging.py
@@ -3,11 +3,13 @@ from pathlib import Path
 import tempfile
 import unittest
 import urllib
+import urllib.request
 from zipfile import ZipFile
 
 import numpy as np
 
 from asammdf import MDF
+from asammdf.blocks.utils import load_can_database
 
 
 class TestCANBusLogging(unittest.TestCase):
@@ -59,15 +61,20 @@ class TestCANBusLogging(unittest.TestCase):
             if input_file.suffix == ".npy"
         ]
 
-        out = mdf.extract_can_logging([dbc])
+        database = load_can_database(dbc)
+        outs = (
+            mdf.extract_can_logging([dbc]),
+            mdf.extract_can_logging((), dbs=[(database, dbc)]),
+        )
 
         for signal in signals:
             name = signal.stem
 
             target = np.load(signal)
-            values = out.get(name).samples
+            for out in outs:
+                values = out.get(name).samples
 
-            self.assertTrue(np.array_equal(values, target))
+                self.assertTrue(np.array_equal(values, target))
 
     def test_j1939_extract(self):
         print("J1939 extract")
@@ -94,15 +101,20 @@ class TestCANBusLogging(unittest.TestCase):
             if input_file.suffix == ".npy"
         ]
 
-        out = mdf.extract_can_logging([dbc])
+        database = load_can_database(dbc)
+        outs = (
+            mdf.extract_can_logging([dbc]),
+            mdf.extract_can_logging((), dbs=[(database, dbc)]),
+        )
 
         for signal in signals:
             name = signal.stem
 
             target = np.load(signal)
-            values = out.get(name).samples
+            for out in outs:
+                values = out.get(name).samples
 
-            self.assertTrue(np.array_equal(values, target))
+                self.assertTrue(np.array_equal(values, target))
 
     def test_j1939_get_can_signal(self):
         print("J1939 get CAN signal")


### PR DESCRIPTION
I use cantools rather than canmatrix. I can convert from a `cantools.Database` to a `canmatrix.CanMatrix` via an in-memory DBC file string. I'd like to be able to extract CAN signals, but this method only accepts filenames and I'd rather not create intermediary files.

I tried to use `MDF4.get_can_signal` but it doesn't seem to work.