### PR TITLE
Update mdf_common.py

### DIFF
--- a/asammdf/blocks/mdf_common.py
+++ b/asammdf/blocks/mdf_common.py
@@ -122,7 +122,7 @@ class MDF_Common:
 
                     entries = self.channels_db[name]
                     if len(entries) > 1:
-                        if self._raise_on_mutiple_occurences:
+                        if self._raise_on_multiple_occurrences:
                             message = (
                                 f'Multiple occurrences for channel "{name}": {entries}. '
                                 'Provide both "group" and "index" arguments'
@@ -162,7 +162,7 @@ class MDF_Common:
                                 raise MdfException(message)
 
                             else:
-                                if self._raise_on_multiple_occurences:
+                                if self._raise_on_multiple_occurrences:
                                     message = (
                                         f'Multiple occurrences for channel "{name}": {entries}. '
                                         'Provide both "group" and "index" arguments'


### PR DESCRIPTION
typing error leads to
AttributeError: 'MDF4' object has no attribute '_raise_on_multiple_occurences'
just one 'l' missing
→ self._raise_on_multiple_occurrences instead of
→ self._raise_on_multiple_occurrences

Sorry for the inconvenience, there were actually two typos in the call and it occured two times in the file, didn't realize that before