### PR TITLE
Don't Write Empty Attachments

### DIFF
--- a/asammdf/blocks/v4_blocks.py
+++ b/asammdf/blocks/v4_blocks.py
@@ -222,7 +222,8 @@ class AttachmentBlock:
 
             else:
                 self.file_name = str(file_name)
-                file_name.write_bytes(data)
+                if len(data) > 0:
+                    file_name.write_bytes(data)
                 embedded_size = 0
                 data = b""
 


### PR DESCRIPTION
When creating an attachment to save to disk, if attachment is not embedded and the provided bytes string is empty, then don't create an empty file.


I have a use-case where a video file attachment is saved along-side the MF4 on disk (i.e. not embedded). I'm processing the MF4 with asammdf, and want to keep the video file attachment in the new resultant MF4 I generate. If I copy the attachment over into the new MF4, it creates an empty file in the current working directory, which to me is unintended behaviour.