### PR TITLE
Fix AttributeError when clicking plot

### DIFF
--- a/asammdf/gui/widgets/plot.py
+++ b/asammdf/gui/widgets/plot.py
@@ -2416,7 +2416,7 @@ class _Plot(pg.PlotWidget):
         axis.setWidth()
 
     def _clicked(self, event):
-        modifiers = QtGui.QApplication.keyboardModifiers()
+        modifiers = QtWidgets.QApplication.keyboardModifiers()
 
         if QtCore.Qt.Key_C not in self.disabled_keys:
 


### PR DESCRIPTION
Fixes error when clicking or right-clicking the plot: `<class 'AttributeError'>: module 'PyQt5.QtGui' has no attribute 'QApplication'`

All other instances of QApplication in the code use `QWidgets.QApplication`