### PR TITLE
Fix drag behavior of TreeWidget

### DIFF
--- a/asammdf/gui/widgets/tree.py
+++ b/asammdf/gui/widgets/tree.py
@@ -11,6 +11,7 @@ class TreeWidget(QtWidgets.QTreeWidget):
         super().__init__(*args, **kwargs)
 
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
+        self.setDragDropMode(QtWidgets.QAbstractItemView.DragOnly)
         self.setUniformRowHeights(True)
 
         self.mode = "Natural sort"
@@ -40,7 +41,7 @@ class TreeWidget(QtWidgets.QTreeWidget):
         else:
             super().keyPressEvent(event)
 
-    def mouseMoveEvent(self, e):
+    def startDrag(self, supportedActions):
         def get_data(item):
             data = set()
             count = item.childCount()
@@ -107,6 +108,4 @@ class TreeWidget(QtWidgets.QTreeWidget):
 
         drag = QtGui.QDrag(self)
         drag.setMimeData(mimeData)
-        drag.setHotSpot(e.pos() - self.rect().topLeft())
-
         drag.exec_(QtCore.Qt.MoveAction)


### PR DESCRIPTION
TreeWidget was using `mouseMoveEvent` to detect a drag, which meant if you moved your mouse even one pixel while clicking an item, you'd start a drag instead (I kept accidentally doing this). I replaced this with `startDrag`, which has a threshold before starting a drag.