### PR TITLE
Use Pattern.search instead of match for search patterns

### DIFF
--- a/asammdf/gui/dialogs/advanced_search.py
+++ b/asammdf/gui/dialogs/advanced_search.py
@@ -77,7 +77,7 @@ class AdvancedSearch(Ui_SearchDialog, QtWidgets.QDialog):
 
             try:
                 pattern = re.compile(f"(?i){pattern}")
-                matches = [name for name in self.channels_db if pattern.match(name)]
+                matches = [name for name in self.channels_db if pattern.search(name)]
                 self.matches.clear()
                 self.matches.addItems(matches)
                 if matches:

--- a/asammdf/gui/dialogs/multi_search.py
+++ b/asammdf/gui/dialogs/multi_search.py
@@ -57,7 +57,7 @@ class MultiSearch(Ui_MultiSearchDialog, QtWidgets.QDialog):
                     match_results = [
                         f"{i:> 2}: {name}"
                         for name in channels_db
-                        if pattern.match(name)
+                        if pattern.search(name)
                     ]
                     results.extend(match_results)
 

--- a/asammdf/gui/widgets/bar.py
+++ b/asammdf/gui/widgets/bar.py
@@ -252,7 +252,7 @@ class Bar(Ui_BarDisplay, QtWidgets.QWidget):
         pattern = pattern.replace("_WILDCARD_", ".*")
 
         pattern = re.compile(f"(?i){pattern}")
-        matches = [name for name in self.signals if pattern.match(name)]
+        matches = [name for name in self.signals if pattern.search(name)]
 
         if not matches:
             self.match.setText("the pattern does not match any channel name")
@@ -312,7 +312,7 @@ class Bar(Ui_BarDisplay, QtWidgets.QWidget):
         pattern = pattern.replace("_WILDCARD_", ".*")
 
         pattern = re.compile(f"(?i){pattern}")
-        matches = [name for name in self.signals if pattern.match(name)]
+        matches = [name for name in self.signals if pattern.search(name)]
 
         if not matches:
             self.match.setText("the pattern does not match any channel name")

--- a/asammdf/gui/widgets/mdi_area.py
+++ b/asammdf/gui/widgets/mdi_area.py
@@ -1310,7 +1310,7 @@ class WithMDIArea:
                     matches = {
                         name: entries[0]
                         for name, entries in self.mdf.channels_db.items()
-                        if pattern.match(name)
+                        if pattern.search(name)
                     }
                 except:
                     print(format_exc())
@@ -1524,7 +1524,7 @@ class WithMDIArea:
                 try:
                     pattern = re.compile(f"(?i){pattern}")
                     matches = [
-                        name for name in self.mdf.channels_db if pattern.match(name)
+                        name for name in self.mdf.channels_db if pattern.search(name)
                     ]
                 except:
                     print(format_exc())
@@ -1940,7 +1940,7 @@ class WithMDIArea:
                     matches = {
                         name: entries[0]
                         for name, entries in self.mdf.channels_db.items()
-                        if pattern.match(name)
+                        if pattern.search(name)
                     }
                 except:
                     print(format_exc())

--- a/asammdf/gui/widgets/numeric.py
+++ b/asammdf/gui/widgets/numeric.py
@@ -277,7 +277,7 @@ class Numeric(Ui_NumericDisplay, QtWidgets.QWidget):
         pattern = pattern.replace("_WILDCARD_", ".*")
 
         pattern = re.compile(f"(?i){pattern}")
-        matches = [name for name in self.signals if pattern.match(name)]
+        matches = [name for name in self.signals if pattern.search(name)]
 
         if not matches:
             self.match.setText("the pattern does not match any channel name")
@@ -337,7 +337,7 @@ class Numeric(Ui_NumericDisplay, QtWidgets.QWidget):
         pattern = pattern.replace("_WILDCARD_", ".*")
 
         pattern = re.compile(f"(?i){pattern}")
-        matches = [name for name in self.signals if pattern.match(name)]
+        matches = [name for name in self.signals if pattern.search(name)]
 
         if not matches:
             self.match.setText("the pattern does not match any channel name")


### PR DESCRIPTION
This replaces `Pattern.match` with `search` for search dialogs. `match` only checks the beginning of the string, while `search` checks anywhere in the string. This means you no longer need to surround search terms with `*` to search for a word anywhere in a channel name.

I'm not sure what was the original reason for using match, but IMO this is more natural (maybe you'll disagree). It matches how a search bar usually works, and is simpler for the more typical case of searching for a word anywhere in a name. You can restore the old behavior in Regex mode with the caret `^`.