### PR TITLE
Prevent freezing during long tasks

### DIFF
--- a/asammdf/gui/utils.py
+++ b/asammdf/gui/utils.py
@@ -330,6 +330,7 @@ def run_thread_with_progress(
                     )
                 else:
                     progress.setRange(0, 0)
+        QtCore.QCoreApplication.processEvents()
         sleep(0.1)
 
     if termination_request:


### PR DESCRIPTION
This makes sure the application continues to process events while a progress bar is showing. Otherwise it can appear to freeze or not update progress.