### PR TITLE
[MDF] Use float_interpolation_mode in to_dataframe call

### DIFF
--- a/asammdf/mdf.py
+++ b/asammdf/mdf.py
@@ -3844,7 +3844,11 @@ class MDF:
                 cycles = len(group_master)
 
                 signals = [
-                    signal.interp(master, self._integer_interpolation)
+                    signal.interp(
+                        master,
+                        integer_interpolation_mode = self._integer_interpolation,
+                        float_interpolation_mode = self._float_interpolation
+                    )
                     if not same_master or len(signal) != cycles
                     else signal
                     for signal in signals


### PR DESCRIPTION
Fixes `interpolation_mode` in the `to_dataframe` call. Previously float interpolation always used the default mode 1.

closes #596 