### PR TITLE
Added characters in file name to be replaced

### DIFF
--- a/asammdf/mdf.py
+++ b/asammdf/mdf.py
@@ -1557,7 +1557,7 @@ class MDF:
                         comment = ""
 
                     if comment:
-                        for char in r' \/:"':
+                        for char in f'\n\t\r\b <>\/:"?*|':
                             comment = comment.replace(char, "_")
                         group_csv_name = (
                             filename.parent


### PR DESCRIPTION
Characters which are illegal (in Windows) for file names can be present in channel comments, escape characters could also be used in comments. 
When exporting to CSV without "single time base" the channel specific csv name contains the comment.

List of illegal characters on Windows: 
https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file

