### PR TITLE
Fix a bug that accidently overwrites hd comments common properties

### DIFF
--- a/asammdf/blocks/v4_blocks.py
+++ b/asammdf/blocks/v4_blocks.py
@@ -5445,7 +5445,7 @@ class HeaderBlock:
                 for e in common_properties:
                     name = e.get("name")
                     if name == "project":
-                        e.text = self.author
+                        e.text = self.project
                         break
                 else:
                     project = ET.SubElement(
@@ -5455,7 +5455,7 @@ class HeaderBlock:
                 for e in common_properties:
                     name = e.get("name")
                     if name == "subject":
-                        e.text = self.author
+                        e.text = self.subject
                         break
                 else:
                     subject = ET.SubElement(


### PR DESCRIPTION
Fix a bug that accidently overwrites hd comments common properties e tags with wrong informations
-> project and subject becoming author if they get passed in an own xml structure
![bugreport](https://user-images.githubusercontent.com/102287355/160453857-8e9e5407-db8c-4c24-8b66-3e5bcfbc635c.png)
.