### PR TITLE
Allow iteration over mdf file object to return raw signals

### DIFF
--- a/asammdf/mdf.py
+++ b/asammdf/mdf.py
@@ -569,8 +569,8 @@ class MDF:
                         ev_type = v4c.EVENT_TYPE_START_RECORDING_TRIGGER
                     event = EventBlock(
                         event_type=ev_type,
-                        sync_base=int(timestamp * 10**9),
-                        sync_factor=10**-9,
+                        sync_base=int(timestamp * 10 ** 9),
+                        sync_factor=10 ** -9,
                         scope_0_addr=0,
                     )
                     event.comment = comment
@@ -728,7 +728,7 @@ class MDF:
             self._read_fragment_size = int(read_fragment_size)
 
         if write_fragment_size is not None:
-            self._write_fragment_size = min(int(write_fragment_size), 4 * 2**20)
+            self._write_fragment_size = min(int(write_fragment_size), 4 * 2 ** 20)
 
         if use_display_names is not None:
             self._use_display_names = bool(use_display_names)
@@ -2566,7 +2566,7 @@ class MDF:
         return stacked
 
     def iter_channels(
-        self, skip_master: bool = True, copy_master: bool = True
+        self, skip_master: bool = True, copy_master: bool = True, raw: bool = False
     ) -> Iterator[Signal]:
         """generator that yields a *Signal* for each non-master channel
 
@@ -2575,7 +2575,9 @@ class MDF:
         skip_master : bool
             do not yield master channels; default *True*
         copy_master : bool
-            copy master for each yielded channel
+            copy master for each yielded channel *True*
+        raw : bool
+            return raw channels instead of converted; default *False*
 
         """
 
@@ -2589,7 +2591,7 @@ class MDF:
                 for ch_index in channel_indexes
             ]
 
-            channels = self.select(channels, copy_master=copy_master)
+            channels = self.select(channels, copy_master=copy_master, raw=raw)
 
             yield from channels
 


### PR DESCRIPTION
When iterating over an MDF file, a channel object is returned.
By default this is a converted channel. So the iteration takes a long time because every channel is converted.
Moreover, there is no possibility to convert a channel back to raw, only from raw to converted.

So I thought adding the option to iterate over channels without converting them would be nice and faster.
The default behavior remains the same, although after looking at the performance difference, I would say that perhaps the default behavior should be iterating raw signals.

The results of the tests I've made: 

```
Iteration speed test over file of size: 103.8 MB
 Regular time to iterate over file: 1.91225 seconds
 Raw time to iterate over file: 0.37859 seconds
 Raw + physical convert time to iterate over file: 1.899 seconds

Iteration speed test over file of size: 510.35 MB
 Regular time to iterate over file: 9.54934 seconds
 Raw time to iterate over file: 1.80888 seconds
 Raw + physical convert time to iterate over file: 9.5655 seconds

Iteration speed test over file of size: 811.18 MB
 Regular time to iterate over file: 14.88366 seconds
 Raw time to iterate over file: 2.72116 seconds
 Raw + physical convert time to iterate over file: 15.32696 seconds
```