### PR TITLE
hdf5 export: Adding timestamps values to each group

### DIFF
--- a/asammdf/mdf.py
+++ b/asammdf/mdf.py
@@ -1411,6 +1411,23 @@ class MDF:
                             group.attrs["master"] = (
                                 self.groups[group_index].channels[master_index].name
                             )
+                            master = self.get(group.attrs["master"], group_index)
+                            if reduce_memory_usage:
+                                master.timestamps = downcast(master.timestamps)
+                            if compression:
+                                dataset = group.create_dataset(
+                                    group.attrs["master"], data=master.timestamps, compression=compression
+                                )
+                            else:
+                                dataset = group.create_dataset(
+                                    group.attrs["master"], data=master.timestamps, dtype=master.timestamps.dtype
+                                )
+                            unit = master.unit.replace("\0", "")
+                            if unit:
+                                dataset.attrs["unit"] = unit
+                            comment = master.comment.replace("\0", "")
+                            if comment:
+                                dataset.attrs["comment"] = comment
 
                         channels = [
                             (None, gp_index, ch_index)


### PR DESCRIPTION
HDF5 export was missing timestamps for the master channel(s) if single_time_base equals False.