### PR TITLE
convert(): removed sharp clips in string parameter

### DIFF
--- a/asammdf/mdf.py
+++ b/asammdf/mdf.py
@@ -842,7 +842,7 @@ class MDF:
             if self._terminate:
                 return
 
-        out._transfer_metadata(self, message=f"Converted from <{self.name}>")
+        out._transfer_metadata(self, message=f"Converted from {self.name}")
         self.configure(copy_on_get=True)
         if self._callback:
             out._callback = out._mdf._callback = self._callback


### PR DESCRIPTION
Calling the convert function with "<...>" inside the message parameter let to an invalid XML Error in the Vector MDF Validator inside the File History Meta Data Block