### PR TITLE
Fix for issue #770. Try to convert to float first, and if that fails convert to bytes

### DIFF
--- a/asammdf/blocks/v4_blocks.py
+++ b/asammdf/blocks/v4_blocks.py
@@ -3425,7 +3425,6 @@ class ChannelConversion(_ChannelConversionBase):
                     ],
                 )
             else:
-
                 ret = np.full(values.size, None, "O")
 
                 idx1 = np.searchsorted(raw_vals, values, side="right") - 1
@@ -3478,10 +3477,10 @@ class ChannelConversion(_ChannelConversionBase):
                                 ret[idx_] = item.convert(values[idx_])
 
                 try:
-                    ret = ret.astype(bytes)
+                    ret = ret.astype("<f8")
                 except:
                     try:
-                        ret = ret.astype("<f8")
+                        ret = ret.astype(bytes)
                     except:
                         if not as_object:
                             ret = np.array(


### PR DESCRIPTION
Alternatively I see that another method is used further up in the codebase, starting on line 3400:
```
                all_bytes = True
                for v in ret.tolist():
                    if not isinstance(v, bytes):
                        all_bytes = False
                        break

                if not all_bytes:
                    try:
                        ret = ret.astype("f8")
                    except:
                        if not as_object:
                            ret = np.array(
                                [np.nan if isinstance(v, bytes) else v for v in ret]
                            )

                else:
                    ret = ret.astype(bytes)
```
We could use this check to see if we need to convert to `float` or `bytes`, but I wouldn't iterate over all items if we can help it.