### PR TITLE
do not limit SciPy version to <1.8.0 for GUI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ setup(
             "PySide6",
             "pyqtgraph>=0.12.4",
             "pyqtlet2>=0.8.0",
-            "scipy<1.8.0",
+            "scipy",
         ],
         "encryption": ["cryptography", "keyring"],
         "symbolic_math": "numexpr3",


### PR DESCRIPTION
it's not possible to install asammdf on windows-systems and python >= 3.10 because there is no SciPy Wheel-Package available for SciPy<1.8.0

Regarding to setup.py:
[export] does not have any version-restriction for SciPy, but [gui] has the <1.8.0 restriction, which most likely is obsolete.
Without that limitation it's possible to install and run asammdf[gui] on python 3.10.