### PR TITLE
gui broken by import

### DIFF
--- a/asammdf/gui/widgets/plot.py
+++ b/asammdf/gui/widgets/plot.py
@@ -15,7 +15,6 @@ import numpy as np
 import pyqtgraph as pg
 import pyqtgraph.canvas.CanvasTemplate_pyside6
 import pyqtgraph.canvas.TransformGuiTemplate_pyside6
-import pyqtgraph.console.template_pyside6
 
 # imports for pyinstaller
 import pyqtgraph.functions as fn
@@ -25,11 +24,13 @@ try:
     import pyqtgraph.graphicsItems.ViewBox.axisCtrlTemplate_pyside6
     import pyqtgraph.GraphicsScene.exportDialogTemplate_pyside6
     import pyqtgraph.imageview.ImageViewTemplate_pyside6
+    import pyqtgraph.console.template_pyside6
 except ImportError:
     import pyqtgraph.graphicsItems.PlotItem.plotConfigTemplate_generic
     import pyqtgraph.graphicsItems.ViewBox.axisCtrlTemplate_generic
     import pyqtgraph.GraphicsScene.exportDialogTemplate_generic
     import pyqtgraph.imageview.ImageViewTemplate_generic
+    import pyqtgraph.console.template_generic
 
 from PySide6 import QtCore, QtGui, QtWidgets
 


### PR DESCRIPTION
this PR is basicaly a cleaner version of #780 
It's the same problem (import not possible), but this PR does NOT contain any other changes (like #780) and the fix does NOT introduce a new try-except block.
It just moves the import into the existing try-except block.

ATTENTION: on python3.10 PR #796 ("do not limit SciPy version to <1.8.0 for GUI") is needed to run tests without errors!