### PR TITLE
bugfix: do not throw a AttributeError in case of an empty dict (conversion)

### DIFF
--- a/src/asammdf/blocks/conversion_utils.py
+++ b/src/asammdf/blocks/conversion_utils.py
@@ -196,7 +196,7 @@ def conversion_transfer(
                     conversion = new_conversion
 
     else:
-        if conversion is None or conversion.id == b"##CC":
+        if not conversion or conversion.id == b"##CC":
             pass
         else:
             conversion_type = conversion.conversion_type


### PR DESCRIPTION
method: conversion_transfer()
it seems that in some cases the argument 'conversion' is an empty dictionary.

an empty dict need to be handled the same way as None (which was already handled).