### PR TITLE
Used regular expression

### DIFF
--- a/src/asammdf/blocks/v4_blocks.py
+++ b/src/asammdf/blocks/v4_blocks.py
@@ -16,7 +16,7 @@ import time
 from traceback import format_exc
 from typing import Any, TYPE_CHECKING
 import xml.etree.ElementTree as ET
-
+import re
 import dateutil.tz
 
 try:
@@ -5383,7 +5383,7 @@ class HeaderBlock:
             comment = string
             try:
                 comment_xml = ET.fromstring(
-                    comment.replace(' xmlns="http://www.asam.net/mdf/v4"', "")
+                    re.sub(r' xmlns=[\'\"]http://www.asam.net/mdf/v4[\'\"]', "", comment)
                 )
             except ET.ParseError as e:
                 self.description = string


### PR DESCRIPTION
Hi Daniel,

This is a small bug fix we realized when we could not extract the comment from the mdf file.
There seems to be an issue with the double and single quotes specified in the replace string.

The comment(variable) string seems to have single quotes in some of our mf4 files -` xmlns='http://www.asam.net/mdf/v4'`. 

Hence I have provided a fix which will take care of both the cases (double & single quotes)

It is also tested on different mf4 files with my colleague Monica K. @kmonica92 

Is this solution good enough if it works for you as well.