### PR TITLE
MdfException - wrong representation

### DIFF
--- a/src/asammdf/blocks/utils.py
+++ b/src/asammdf/blocks/utils.py
@@ -171,7 +171,7 @@ class MdfException(Exception):
     """MDF Exception class"""
 
     def __repr__(self):
-        return f"asammdf MdfException: {self.text}"
+        return f"asammdf MdfException: {self.args[0]}"
 
 
 def extract_xml_comment(comment: str) -> str:


### PR DESCRIPTION
I don't know what the original throught was, but the exception text is stored in args[0].

