### PR TITLE
QtSignal.emit() missing parameter

### DIFF
--- a/src/asammdf/gui/utils.py
+++ b/src/asammdf/gui/utils.py
@@ -306,7 +306,7 @@ class ProgressDialog(QtWidgets.QProgressDialog):
         self.error = error
 
     def thread_complete(self):
-        self.finished.emit()
+        self.finished.emit(self.parent)
         self.thread_finished = True
         super().close()
 


### PR DESCRIPTION
When modifying/extracting bus with the GUI, at the end of the process, there is an exception where the self.process QtSignal is missing a parameter.
This is because this signal is connected to a function expecting (self) parameter but none is given
The solution is to pass self.parent to it.
