### PR TITLE
check the correct dtype of the correct part of the share

### DIFF
--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -4995,7 +4995,7 @@ class MDF4(MDF_Common):
                     sig_type = v4c.SIGNAL_TYPE_ARRAY
 
             if sig_type in (v4c.SIGNAL_TYPE_SCALAR, v4c.SIGNAL_TYPE_STRING):
-                s_type, s_size = fmt_to_datatype_v4(samples.dtype, samples.shape)
+                s_type, s_size = fmt_to_datatype_v4(samples.dtype, samples.shape[1:)
                 byte_size = s_size // 8 or 1
 
                 # add channel block

--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -4995,7 +4995,7 @@ class MDF4(MDF_Common):
                     sig_type = v4c.SIGNAL_TYPE_ARRAY
 
             if sig_type in (v4c.SIGNAL_TYPE_SCALAR, v4c.SIGNAL_TYPE_STRING):
-                s_type, s_size = fmt_to_datatype_v4(samples.dtype, samples.shape[1:)
+                s_type, s_size = fmt_to_datatype_v4(samples.dtype, samples.shape[1:])
                 byte_size = s_size // 8 or 1
 
                 # add channel block


### PR DESCRIPTION
When creating a signal which consists of an array of different types of variables, the dtype of all of the sub channels is set to be Byte Array instead of its correct type. By changing the shape - the correct type is set.
(encountered while trying to fake a raw bus channel)