### PR TITLE
add try/except to guard against TypeError (int to None comparison)

### DIFF
--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -2515,12 +2515,15 @@ class MDF:
                                     _ch_name
                                 ):
                                     if _second_gp_idx == _gp_idx:
-                                        vlsd_max_length[key] = max(
-                                            vlsd_max_length[key],
-                                            _file.determine_max_vlsd_sample_size(
-                                                _second_gp_idx, _second_ch_idx
-                                            ),
-                                        )
+                                        try:
+                                            vlsd_max_length[key] = max(
+                                                vlsd_max_length[key],
+                                                _file.determine_max_vlsd_sample_size(
+                                                    _second_gp_idx, _second_ch_idx
+                                                ),
+                                            )
+                                        except TypeError:
+                                            pass
                                         break
                                 else:
                                     raise MdfException(


### PR DESCRIPTION
max() function compares None to int which in python2 results in the int to be always bigger. But in python3 it returns TypeError exception. 
Since the result of max() is assigned to the first of it's arguments which is int then the exception can be handled with pass.