### PR TITLE
Fix Group Activation from ContextMenu

### DIFF
--- a/requirements_exe_build.txt
+++ b/requirements_exe_build.txt
@@ -10,6 +10,7 @@ natsort
 psutil 
 PySide6==6.2.2
 pyqtgraph==0.12.4
+QtPy==2.3.1
 pyqtlet2
 pyopengl
 h5py 

--- a/src/asammdf/gui/widgets/tree.py
+++ b/src/asammdf/gui/widgets/tree.py
@@ -1037,10 +1037,12 @@ class ChannelsTreeWidget(QtWidgets.QTreeWidget):
             QtWidgets.QApplication.instance().clipboard().setText("\n".join(texts))
 
         elif action_text == "Activate group":
-            for item in self.selectedItems():
-                if item.type() == item.Group and item.isDisabled():
-                    item.set_disabled(False)
-                    item.setIcon(item.NameColumn, QtGui.QIcon(":/open.png"))
+            # Selected Items will not be retrieved if there are disabled.
+            # So Activating multiple groups will not be possible.
+            # for item in self.selectedItems():
+            if item.type() == item.Group and item.isDisabled():
+                item.set_disabled(False)
+                item.setIcon(item.NameColumn, QtGui.QIcon(":/open.png"))
             self.group_activation_changed.emit()
 
         elif action_text == "Deactivate groups":

--- a/src/asammdf/version.py
+++ b/src/asammdf/version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """ asammdf version module """
 
-__version__ = "7.3.15.dev3"
+__version__ = "7.3.15.dev4"

--- a/test/asammdf/gui/widgets/test_PlotWidget.py
+++ b/test/asammdf/gui/widgets/test_PlotWidget.py
@@ -145,7 +145,7 @@ class TestDoubleClick(TestPlotWidget):
                 QtTest.QTest.keyClick(plot.channel_selection, QtCore.Qt.Key_Down)
                 self.processEvents()
 
-            # Evaluate that item is still 2nd one because
+            # Evaluate that item is the one from the group
             selectedItems = plot.channel_selection.selectedItems()
             self.assertEqual(1, len(selectedItems))
             selectedItem = selectedItems[0].text(self.Column.NAME)


### PR DESCRIPTION
Package `QtPy` (dependency of `pyqtlet`) was freezed to `2.3.1`.
It seems that with newer one (`2.4.0`), pyinstaller cannot build binary:
```python
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.12/x64/bin/pyinstaller", line 8, in <module>
    sys.exit(run())
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/PyInstaller/__main__.py", line [124](https://github.com/danielhrisca/asammdf/actions/runs/6047454325/job/16410940716?pr=901#step:5:125), in run
    run_build(pyi_config, spec_file, **vars(args))
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/PyInstaller/__main__.py", line 58, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/PyInstaller/building/build_main.py", line 803, in main
    build(specfile, distpath, workpath, clean_build)
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/PyInstaller/building/build_main.py", line 725, in build
    exec(code, spec_namespace)
  File "asammdf.spec", line 20, in <module>
    import pyqtlet2
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/pyqtlet2/__init__.py", line 8, in <module>
    from .mapwidget import MapWidget
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/pyqtlet2/mapwidget.py", line 5, in <module>
    from qtpy.QtWebEngineWidgets import QWebEngineView, QWebEnginePage
  File "/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/qtpy/QtWebEngineWidgets.py", line 64, in <module>
    from PySide6.QtWebEngineCore import (
ImportError: cannot import name 'QWebEngineScrip' from 'PySide6.QtWebEngineCore' (/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/PySide6/QtWebEngineCore.abi3.so)
```