### PR TITLE
Add support for elist in mf4 header comment

### DIFF
--- a/src/asammdf/blocks/v4_blocks.py
+++ b/src/asammdf/blocks/v4_blocks.py
@@ -5643,24 +5643,28 @@ class HeaderBlock:
         self._common_properties.clear()
 
         def parse_common_properties(root):
+            root_name = root.get("name")
             info = {}
-            if root.tag in ("list", "tree"):
-                info[root.get("name")] = {}
+            if root.tag in ("list", "tree", "elist"):
+                info[root_name] = {}
             try:
                 for element in root:
                     name = element.get("name")
 
                     if element.tag == "e":
                         if root.tag == "tree":
-                            info[root.get("name")][name] = element.text or ""
+                            info[root_name][name] = element.text or ""
                         else:
                             info[name] = element.text or ""
 
-                    elif element.tag in ("list", "tree"):
+                    elif element.tag in ("list", "tree", "elist"):
                         info.update(parse_common_properties(element))
 
                     elif element.tag == "li":
-                        info[root.get("name")].update(parse_common_properties(element))
+                        info[root_name].update(parse_common_properties(element))
+
+                    elif element.tag == "eli":
+                        info[root_name][str(len(info[root_name]))] = element.text or ""
             except:
                 print(format_exc())
 


### PR DESCRIPTION
Hello,

I do not know why you decided to convert everything in the header comment to the tree structure. But I would like to add this simple support for the elist so it is not lost in the header.

Previously elist was working in version 7.0.7