### PR TITLE
Activate pyflakes rules in ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 23.9.1
+    rev: 23.10.0
     hooks:
       - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.0
+    rev: v0.1.1
     hooks:
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,14 @@ skip = "pp* *_ppc64le *_s390x *-musllinux* cp312-*"  # skip pypy and irrelevant 
 
 [tool.ruff]
 select = [
+    "F",  # pyflakes
     "UP",  # pyupgrade
     "I",  # isort
+]
+ignore = [
+    "F401",  # unused-import
+    "F821",  # undefined-name
+    "F841",  # unused-variable
 ]
 exclude = ["./src/asammdf/gui/ui"]
 target-version = "py38"

--- a/src/asammdf/blocks/conversion_utils.py
+++ b/src/asammdf/blocks/conversion_utils.py
@@ -5,7 +5,7 @@ asammdf utility functions for channel conversions
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import Any, Union
+from typing import Any
 
 from ..types import ChannelConversionType
 from . import v2_v3_blocks as v3b

--- a/src/asammdf/blocks/conversion_utils.py
+++ b/src/asammdf/blocks/conversion_utils.py
@@ -147,7 +147,7 @@ def conversion_transfer(
                         conversion.referenced_blocks["default_addr"],
                         v4b.ChannelConversion,
                     ):
-                        default_addr = conversion.referenced_blocks[f"default_addr"].name.encode("latin-1")
+                        default_addr = conversion.referenced_blocks["default_addr"].name.encode("latin-1")
                     else:
                         default_addr = conversion.referenced_blocks["default_addr"]
                     new_conversion.referenced_blocks["default_addr"] = default_addr
@@ -177,7 +177,7 @@ def conversion_transfer(
                         conversion.referenced_blocks["default_addr"],
                         v4b.ChannelConversion,
                     ):
-                        default_addr = conversion.referenced_blocks[f"default_addr"].name.encode("latin-1")
+                        default_addr = conversion.referenced_blocks["default_addr"].name.encode("latin-1")
                     else:
                         default_addr = conversion.referenced_blocks["default_addr"]
                     new_conversion.referenced_blocks["default_addr"] = default_addr
@@ -345,9 +345,9 @@ def from_dict(conversion: dict[str, Any]) -> v4b.ChannelConversion:
 
         val = conversion.get("default_addr", b"")
         if isinstance(val, str):
-            conversion[f"default_addr"] = val.encode("utf-8")
+            conversion["default_addr"] = val.encode("utf-8")
         elif isinstance(val, dict):
-            conversion[f"default_addr"] = from_dict(val)
+            conversion["default_addr"] = from_dict(val)
 
         conversion["ref_param_nr"] = nr + 1
         conversion = v4b.ChannelConversion(**conversion)
@@ -367,9 +367,9 @@ def from_dict(conversion: dict[str, Any]) -> v4b.ChannelConversion:
 
         val = conversion.get("default_addr", b"")
         if isinstance(val, str):
-            conversion[f"default_addr"] = val.encode("utf-8")
+            conversion["default_addr"] = val.encode("utf-8")
         elif isinstance(val, dict):
-            conversion[f"default_addr"] = from_dict(val)
+            conversion["default_addr"] = from_dict(val)
         conversion = v4b.ChannelConversion(**conversion)
 
     else:

--- a/src/asammdf/blocks/mdf_v3.py
+++ b/src/asammdf/blocks/mdf_v3.py
@@ -46,7 +46,6 @@ from typing_extensions import Literal, TypedDict
 from .. import tool
 from ..signal import Signal
 from ..types import ChannelsType, CompressionType, RasterType, StrPathType
-from ..version import __version__
 from . import v2_v3_constants as v23c
 from .conversion_utils import conversion_transfer
 from .cutils import get_channel_raw_bytes

--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -9496,17 +9496,17 @@ class MDF4(MDF_Common):
                                     gp_nr, ch_nr = dep.output_quantity_channel
                                     grp = self.groups[gp_nr]
                                     ch = grp.channels[ch_nr]
-                                    dep[f"output_quantity_dg_addr"] = grp.data_group.address
-                                    dep[f"output_quantity_cg_addr"] = grp.channel_group.address
-                                    dep[f"output_quantity_ch_addr"] = ch.address
+                                    dep["output_quantity_dg_addr"] = grp.data_group.address
+                                    dep["output_quantity_cg_addr"] = grp.channel_group.address
+                                    dep["output_quantity_ch_addr"] = ch.address
 
                                 if dep.comparison_quantity_channel:
                                     gp_nr, ch_nr = dep.comparison_quantity_channel
                                     grp = self.groups[gp_nr]
                                     ch = grp.channels[ch_nr]
-                                    dep[f"comparison_quantity_dg_addr"] = grp.data_group.address
-                                    dep[f"comparison_quantity_cg_addr"] = grp.channel_group.address
-                                    dep[f"comparison_quantity_ch_addr"] = ch.address
+                                    dep["comparison_quantity_dg_addr"] = grp.data_group.address
+                                    dep["comparison_quantity_cg_addr"] = grp.channel_group.address
+                                    dep["comparison_quantity_ch_addr"] = ch.address
 
                                 for i, (gp_nr, ch_nr) in enumerate(dep.axis_channels):
                                     grp = self.groups[gp_nr]
@@ -10314,7 +10314,7 @@ class MDF4(MDF_Common):
                 ):
                     try:
                         self._process_can_logging(index, group)
-                    except Exception as e:
+                    except Exception:
                         message = f"Error during CAN logging processing: {format_exc()}"
                         logger.error(message)
 

--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -24,7 +24,6 @@ from time import sleep
 from traceback import format_exc
 from typing import Any, overload
 from zipfile import ZIP_DEFLATED, ZipFile
-from zlib import decompress
 
 from typing_extensions import Literal
 
@@ -148,7 +147,7 @@ from .v4_blocks import (
 try:
     from isal.isal_zlib import decompress
 except ImportError:
-    pass
+    from zlib import decompress
 
 
 MASTER_CHANNELS = (v4c.CHANNEL_TYPE_MASTER, v4c.CHANNEL_TYPE_VIRTUAL_MASTER)

--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import bisect
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Iterator, Sequence, Sized
+from collections.abc import Iterator, Sequence
 from copy import deepcopy
 from datetime import datetime
 from functools import lru_cache
@@ -20,7 +20,6 @@ from pathlib import Path
 import shutil
 import sys
 from tempfile import gettempdir, NamedTemporaryFile
-from time import sleep
 from traceback import format_exc
 from typing import Any, overload
 from zipfile import ZIP_DEFLATED, ZipFile
@@ -45,10 +44,8 @@ from numpy import (
     array,
     array_equal,
     bool_,
-    bytes_,
     column_stack,
     concatenate,
-    cumsum,
     dtype,
     empty,
     fliplr,
@@ -85,7 +82,6 @@ from ..types import (
     StrPathType,
     WritableBufferType,
 )
-from ..version import __version__
 from . import bus_logging_utils
 from . import v4_constants as v4c
 from .conversion_utils import conversion_transfer
@@ -112,7 +108,6 @@ from .utils import (
     is_file_like,
     load_can_database,
     MdfException,
-    sanitize_xml,
     SignalDataBlockInfo,
     TERMINATED,
     UINT8_uf,
@@ -176,8 +171,6 @@ from .cutils import (
     extract,
     get_channel_raw_bytes,
     get_vlsd_max_sample_size,
-    get_vlsd_offsets,
-    lengths,
     sort_data_block,
 )
 

--- a/src/asammdf/blocks/utils.py
+++ b/src/asammdf/blocks/utils.py
@@ -931,15 +931,15 @@ def count_channel_groups(
                             ch_count += 1
                             ch_addr = UINT64_uf(stream, ch_addr + 24)[0]
                             if ch_addr >= file_limit:
-                                raise MdfException(f"File is a corrupted MDF file - Invalid CH block address")
+                                raise MdfException("File is a corrupted MDF file - Invalid CH block address")
 
                     cg_addr = UINT64_uf(stream, cg_addr + 24)[0]
                     if cg_addr >= file_limit:
-                        raise MdfException(f"File is a corrupted MDF file - Invalid CG block address")
+                        raise MdfException("File is a corrupted MDF file - Invalid CG block address")
 
                 dg_addr = UINT64_uf(stream, dg_addr + 24)[0]
                 if dg_addr >= file_limit:
-                    raise MdfException(f"File is a corrupted MDF file - Invalid DG block address")
+                    raise MdfException("File is a corrupted MDF file - Invalid DG block address")
         else:
             stream.seek(88, 0)
             dg_addr = UINT64_u(stream.read(8))[0]
@@ -956,18 +956,18 @@ def count_channel_groups(
                             stream.seek(ch_addr + 24)
                             ch_addr = UINT64_u(stream.read(8))[0]
                             if ch_addr >= file_limit:
-                                raise MdfException(f"File is a corrupted MDF file - Invalid CH block address")
+                                raise MdfException("File is a corrupted MDF file - Invalid CH block address")
 
                     stream.seek(cg_addr + 24)
                     cg_addr = UINT64_u(stream.read(8))[0]
                     if cg_addr >= file_limit:
-                        raise MdfException(f"File is a corrupted MDF file - Invalid CG block address")
+                        raise MdfException("File is a corrupted MDF file - Invalid CG block address")
 
                 stream.seek(dg_addr + 24)
                 dg_addr = UINT64_u(stream.read(8))[0]
 
                 if dg_addr >= file_limit:
-                    raise MdfException(f"File is a corrupted MDF file - Invalid DG block address")
+                    raise MdfException("File is a corrupted MDF file - Invalid DG block address")
 
     else:
         stream.seek(68, 0)
@@ -985,18 +985,18 @@ def count_channel_groups(
                         stream.seek(ch_addr + 4)
                         ch_addr = UINT32_u(stream.read(4))[0]
                         if ch_addr >= file_limit:
-                            raise MdfException(f"File is a corrupted MDF file - Invalid CH block address")
+                            raise MdfException("File is a corrupted MDF file - Invalid CH block address")
 
                 stream.seek(cg_addr + 4)
                 cg_addr = UINT32_u(stream.read(4))[0]
                 if cg_addr >= file_limit:
-                    raise MdfException(f"File is a corrupted MDF file - Invalid CG block address")
+                    raise MdfException("File is a corrupted MDF file - Invalid CG block address")
 
             stream.seek(dg_addr + 4)
             dg_addr = UINT32_u(stream.read(4))[0]
 
             if dg_addr >= file_limit:
-                raise MdfException(f"File is a corrupted MDF file - Invalid DG block address")
+                raise MdfException("File is a corrupted MDF file - Invalid DG block address")
 
     return count, ch_count
 

--- a/src/asammdf/blocks/v2_v3_blocks.py
+++ b/src/asammdf/blocks/v2_v3_blocks.py
@@ -2767,7 +2767,7 @@ class HeaderBlock:
             comment = string
             try:
                 comment_xml = ET.fromstring(comment.replace(' xmlns="http://www.asam.net/mdf/v4"', ""))
-            except ET.ParseError as e:
+            except ET.ParseError:
                 self.description = string
             else:
                 description = comment_xml.find(".//TX")

--- a/src/asammdf/blocks/v2_v3_blocks.py
+++ b/src/asammdf/blocks/v2_v3_blocks.py
@@ -27,7 +27,6 @@ import numpy as np
 from ..version import __version__
 from . import v2_v3_constants as v23c
 from .utils import (
-    escape_xml_string,
     get_fields,
     get_text_v3,
     MdfException,

--- a/src/asammdf/blocks/v4_blocks.py
+++ b/src/asammdf/blocks/v4_blocks.py
@@ -4,9 +4,7 @@ classes that implement the blocks for MDF version 4
 
 from __future__ import annotations
 
-from bisect import bisect_left, bisect_right
 from datetime import datetime, timedelta, timezone
-from functools import lru_cache
 from hashlib import md5
 import logging
 from pathlib import Path
@@ -52,7 +50,6 @@ from .utils import (
     get_text_v4,
     is_file_like,
     MdfException,
-    sanitize_xml,
     UINT8_uf,
     UINT64_u,
     UINT64_uf,

--- a/src/asammdf/blocks/v4_blocks.py
+++ b/src/asammdf/blocks/v4_blocks.py
@@ -1483,15 +1483,15 @@ class ChannelArrayBlock(_ChannelArrayBlockBase):
                     links = links[dims_nr * 3 :]
 
                 if self.flags & v4c.FLAG_CA_OUTPUT_QUANTITY:
-                    self[f"output_quantity_dg_addr"] = links[0]
-                    self[f"output_quantity_cg_addr"] = links[1]
-                    self[f"output_quantity_ch_addr"] = links[2]
+                    self["output_quantity_dg_addr"] = links[0]
+                    self["output_quantity_cg_addr"] = links[1]
+                    self["output_quantity_ch_addr"] = links[2]
                     links = links[3:]
 
                 if self.flags & v4c.FLAG_CA_COMPARISON_QUANTITY:
-                    self[f"comparison_quantity_dg_addr"] = links[0]
-                    self[f"comparison_quantity_cg_addr"] = links[1]
-                    self[f"comparison_quantity_ch_addr"] = links[2]
+                    self["comparison_quantity_dg_addr"] = links[0]
+                    self["comparison_quantity_cg_addr"] = links[1]
+                    self["comparison_quantity_ch_addr"] = links[2]
                     links = links[3:]
 
                 if self.flags & v4c.FLAG_CA_AXIS:
@@ -1568,15 +1568,15 @@ class ChannelArrayBlock(_ChannelArrayBlockBase):
                     links = links[dims_nr * 3 :]
 
                 if self.flags & v4c.FLAG_CA_OUTPUT_QUANTITY:
-                    self[f"output_quantity_dg_addr"] = links[0]
-                    self[f"output_quantity_cg_addr"] = links[1]
-                    self[f"output_quantity_ch_addr"] = links[2]
+                    self["output_quantity_dg_addr"] = links[0]
+                    self["output_quantity_cg_addr"] = links[1]
+                    self["output_quantity_ch_addr"] = links[2]
                     links = links[3:]
 
                 if self.flags & v4c.FLAG_CA_COMPARISON_QUANTITY:
-                    self[f"comparison_quantity_dg_addr"] = links[0]
-                    self[f"comparison_quantity_cg_addr"] = links[1]
-                    self[f"comparison_quantity_ch_addr"] = links[2]
+                    self["comparison_quantity_dg_addr"] = links[0]
+                    self["comparison_quantity_cg_addr"] = links[1]
+                    self["comparison_quantity_ch_addr"] = links[2]
                     links = links[3:]
 
                 if self.flags & v4c.FLAG_CA_AXIS:
@@ -1723,16 +1723,16 @@ class ChannelArrayBlock(_ChannelArrayBlockBase):
 
         if flags & v4c.FLAG_CA_OUTPUT_QUANTITY:
             keys += (
-                f"output_quantity_dg_addr",
-                f"output_quantity_cg_addr",
-                f"output_quantity_ch_addr",
+                "output_quantity_dg_addr",
+                "output_quantity_cg_addr",
+                "output_quantity_ch_addr",
             )
 
         if flags & v4c.FLAG_CA_COMPARISON_QUANTITY:
             keys += (
-                f"comparison_quantity_dg_addr",
-                f"comparison_quantity_cg_addr",
-                f"comparison_quantity_ch_addr",
+                "comparison_quantity_dg_addr",
+                "comparison_quantity_cg_addr",
+                "comparison_quantity_ch_addr",
             )
 
         if flags & v4c.FLAG_CA_AXIS:
@@ -2153,7 +2153,7 @@ comment: {self.comment}
 
                     lines[-1] += f" (= '{sep}')"
                 else:
-                    lines[-1] += f" (= <undefined>)"
+                    lines[-1] += " (= <undefined>)"
 
         for line in lines:
             if not line:

--- a/src/asammdf/gui/dialogs/advanced_search.py
+++ b/src/asammdf/gui/dialogs/advanced_search.py
@@ -5,8 +5,7 @@ from traceback import format_exc
 from natsort import natsorted
 from PySide6 import QtCore, QtWidgets
 
-from ...blocks.utils import extract_xml_comment, timeit
-from ..ui import resource_rc
+from ...blocks.utils import extract_xml_comment
 from ..ui.search_dialog import Ui_SearchDialog
 from .messagebox import MessageBox
 from .range_editor import RangeEditor

--- a/src/asammdf/gui/dialogs/channel_group_info.py
+++ b/src/asammdf/gui/dialogs/channel_group_info.py
@@ -1,6 +1,5 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from ..ui import resource_rc
 from ..widgets.channel_group_info import ChannelGroupInfoWidget
 
 

--- a/src/asammdf/gui/dialogs/channel_info.py
+++ b/src/asammdf/gui/dialogs/channel_info.py
@@ -1,6 +1,5 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from ..ui import resource_rc
 from ..widgets.channel_info import ChannelInfoWidget
 
 

--- a/src/asammdf/gui/dialogs/conversion_editor.py
+++ b/src/asammdf/gui/dialogs/conversion_editor.py
@@ -4,7 +4,6 @@ from PySide6 import QtCore, QtGui, QtWidgets
 from asammdf.blocks import v4_constants as v4c
 from asammdf.blocks.conversion_utils import from_dict
 
-from ..ui import resource_rc
 from ..ui.define_conversion_dialog import Ui_ConversionDialog
 from .messagebox import MessageBox
 

--- a/src/asammdf/gui/dialogs/conversion_editor.py
+++ b/src/asammdf/gui/dialogs/conversion_editor.py
@@ -335,13 +335,13 @@ class ConversionEditor(Ui_ConversionDialog, QtWidgets.QDialog):
         return conversion
 
     def edit_vtt_default_conversion(self):
-        dlg = ConversionEditor(f"default", self.vtt_default_conversion, parent=self)
+        dlg = ConversionEditor("default", self.vtt_default_conversion, parent=self)
         dlg.exec_()
         if dlg.pressed_button == "apply":
             self.vtt_default_conversion = dlg.conversion()
 
     def edit_vrtt_default_conversion(self):
-        dlg = ConversionEditor(f"default", self.vrtt_default_conversion, parent=self)
+        dlg = ConversionEditor("default", self.vrtt_default_conversion, parent=self)
         dlg.exec_()
         if dlg.pressed_button == "apply":
             self.vrtt_default_conversion = dlg.conversion()

--- a/src/asammdf/gui/dialogs/define_channel.py
+++ b/src/asammdf/gui/dialogs/define_channel.py
@@ -275,6 +275,6 @@ class DefineChannel(Ui_ComputedChannel, QtWidgets.QDialog):
             else:
                 MessageBox.warning(
                     self,
-                    f"No function selected",
-                    f"Please select one of the fucntion defined in the Functions manager",
+                    "No function selected",
+                    "Please select one of the fucntion defined in the Functions manager",
                 )

--- a/src/asammdf/gui/dialogs/define_channel.py
+++ b/src/asammdf/gui/dialogs/define_channel.py
@@ -2,12 +2,10 @@ from functools import partial
 import inspect
 import os
 import re
-from traceback import format_exc
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from ...signal import Signal
-from ..ui import resource_rc
 from ..ui.define_channel_dialog import Ui_ComputedChannel
 from ..utils import computation_to_python_function
 from ..widgets.python_highlighter import PythonHighlighter

--- a/src/asammdf/gui/dialogs/error_dialog.py
+++ b/src/asammdf/gui/dialogs/error_dialog.py
@@ -1,9 +1,5 @@
-from threading import Thread
-from time import sleep
-
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from ..ui import resource_rc
 from ..ui.error_dialog import Ui_ErrorDialog
 
 

--- a/src/asammdf/gui/dialogs/functions_manager.py
+++ b/src/asammdf/gui/dialogs/functions_manager.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 import os
-from traceback import format_exc
 
 from PySide6 import QtCore, QtWidgets
 

--- a/src/asammdf/gui/dialogs/gps_dialog.py
+++ b/src/asammdf/gui/dialogs/gps_dialog.py
@@ -1,9 +1,5 @@
-import re
+from PySide6 import QtWidgets
 
-from natsort import natsorted
-from PySide6 import QtCore, QtWidgets
-
-from ..ui import resource_rc
 from ..ui.gps_dialog import Ui_GPSDialog
 from .advanced_search import AdvancedSearch
 

--- a/src/asammdf/gui/dialogs/messagebox.py
+++ b/src/asammdf/gui/dialogs/messagebox.py
@@ -1,4 +1,4 @@
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 DEFAULT_TIMEOUT = 60
 

--- a/src/asammdf/gui/dialogs/multi_search.py
+++ b/src/asammdf/gui/dialogs/multi_search.py
@@ -1,12 +1,10 @@
 import os
 import re
 from textwrap import wrap
-from traceback import format_exc
 
 from natsort import natsorted
 from PySide6 import QtCore, QtWidgets
 
-from ..ui import resource_rc
 from ..ui.multi_search_dialog import Ui_MultiSearchDialog
 from .messagebox import MessageBox
 

--- a/src/asammdf/gui/dialogs/range_editor.py
+++ b/src/asammdf/gui/dialogs/range_editor.py
@@ -1,6 +1,5 @@
 from PySide6 import QtCore, QtWidgets
 
-from ..ui import resource_rc
 from ..ui.range_editor_dialog import Ui_RangeDialog
 from ..widgets.range_widget import RangeWidget
 

--- a/src/asammdf/gui/dialogs/simple_search.py
+++ b/src/asammdf/gui/dialogs/simple_search.py
@@ -1,11 +1,10 @@
-from functools import partial
 import os
 import re
 import sys
 from traceback import format_exc
 
 from natsort import natsorted
-from PySide6 import QtCore, QtWidgets
+from PySide6 import QtWidgets
 
 from asammdf.gui.utils import excepthook
 

--- a/src/asammdf/gui/dialogs/window_selection_dialog.py
+++ b/src/asammdf/gui/dialogs/window_selection_dialog.py
@@ -1,6 +1,5 @@
 from PySide6 import QtWidgets
 
-from ..ui import resource_rc
 from ..ui.windows_selection_dialog import Ui_WindowSelectionDialog
 
 

--- a/src/asammdf/gui/plot.py
+++ b/src/asammdf/gui/plot.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import sys
 
 from ..blocks.utils import plausible_timestamps
 

--- a/src/asammdf/gui/utils.py
+++ b/src/asammdf/gui/utils.py
@@ -10,7 +10,7 @@ import re
 import sys
 from textwrap import indent
 from threading import Thread
-from time import perf_counter, sleep
+from time import sleep
 import traceback
 from traceback import format_exc
 from typing import Dict, Union

--- a/src/asammdf/gui/utils.py
+++ b/src/asammdf/gui/utils.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 from pyqtgraph import functions as fn
 from PySide6 import QtCore, QtGui, QtWidgets
-from PySide6.QtCore import QThreadPool, Signal
+from PySide6.QtCore import QThreadPool
 
 from ..blocks.options import FloatInterpolation, IntegerInterpolation
 from ..signal import Signal

--- a/src/asammdf/gui/widgets/attachment.py
+++ b/src/asammdf/gui/widgets/attachment.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from PySide6 import QtWidgets
 
 from ...blocks.utils import extract_encryption_information
-from ..ui import resource_rc
 from ..ui.attachment import Ui_Attachment
 
 

--- a/src/asammdf/gui/widgets/bar.py
+++ b/src/asammdf/gui/widgets/bar.py
@@ -307,7 +307,7 @@ class Bar(Ui_BarDisplay, QtWidgets.QWidget):
         try:
             target = float(self.target.text().strip())
         except:
-            self.match.setText(f"the target must a numeric value")
+            self.match.setText("the target must a numeric value")
         else:
             if target.is_integer():
                 target = int(target)
@@ -339,7 +339,7 @@ class Bar(Ui_BarDisplay, QtWidgets.QWidget):
                 self.timestamp.setValue(timestamp)
                 self.match.setText(f"condition found for {signal_name}")
             else:
-                self.match.setText(f"condition not found")
+                self.match.setText("condition not found")
 
     def set_format(self, fmt):
         self.format = fmt

--- a/src/asammdf/gui/widgets/bar.py
+++ b/src/asammdf/gui/widgets/bar.py
@@ -1,13 +1,11 @@
 import os
 import re
 
-from natsort import natsorted
 import numpy as np
 from numpy import searchsorted
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from ..dialogs.messagebox import MessageBox
-from ..ui import resource_rc
 from ..ui.bar import Ui_BarDisplay
 from ..utils import COLORS
 from .channel_bar_display import ChannelBarDisplay

--- a/src/asammdf/gui/widgets/batch.py
+++ b/src/asammdf/gui/widgets/batch.py
@@ -659,7 +659,7 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
                 self,
                 "Select output measurement file",
                 "",
-                f"MDF version 4 files (*.mf4 *.mf4z);;All files (*.*)",
+                "MDF version 4 files (*.mf4 *.mf4z);;All files (*.*)",
                 "MDF version 4 files (*.mf4 *.mf4z)",
             )
 
@@ -816,7 +816,7 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
                 self,
                 "Select output measurement file",
                 "",
-                f"MDF version 4 files (*.mf4 *.mf4z);;All files (*.*)",
+                "MDF version 4 files (*.mf4 *.mf4z);;All files (*.*)",
                 "MDF version 4 files (*.mf4 *.mf4z)",
             )
 

--- a/src/asammdf/gui/widgets/batch.py
+++ b/src/asammdf/gui/widgets/batch.py
@@ -1,30 +1,24 @@
-from datetime import datetime, timedelta, timezone
-import json
+from datetime import timezone
 import os
 from pathlib import Path
-from tempfile import gettempdir
 from traceback import format_exc
 
 from natsort import natsorted
-import psutil
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from ...blocks.utils import (
     extract_xml_comment,
     load_channel_names_from_file,
     load_lab,
-    timeit,
 )
 from ...blocks.v2_v3_blocks import HeaderBlock as HeaderBlockV3
 from ...blocks.v4_blocks import HeaderBlock as HeaderBlockV4
 from ...mdf import MDF, SUPPORTED_VERSIONS
 from ..dialogs.advanced_search import AdvancedSearch
 from ..dialogs.messagebox import MessageBox
-from ..ui import resource_rc
 from ..ui.batch_widget import Ui_batch_widget
 from ..utils import HelperChannel, setup_progress, TERMINATED
 from .database_item import DatabaseItem
-from .list import MinimalListWidget
 from .tree import add_children
 from .tree_item import TreeItem
 

--- a/src/asammdf/gui/widgets/batch.py
+++ b/src/asammdf/gui/widgets/batch.py
@@ -13,7 +13,6 @@ from ...blocks.utils import (
     extract_xml_comment,
     load_channel_names_from_file,
     load_lab,
-    TERMINATED,
     timeit,
 )
 from ...blocks.v2_v3_blocks import HeaderBlock as HeaderBlockV3

--- a/src/asammdf/gui/widgets/bus_database_manager.py
+++ b/src/asammdf/gui/widgets/bus_database_manager.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from PySide6 import QtCore, QtWidgets
+from PySide6 import QtWidgets
 
 from ..ui.bus_database_manager import Ui_BusDatabaseManager
 from .database_item import DatabaseItem

--- a/src/asammdf/gui/widgets/can_bus_trace.py
+++ b/src/asammdf/gui/widgets/can_bus_trace.py
@@ -1,9 +1,8 @@
-import datetime
 import logging
 
 import dateutil.tz
 import pandas as pd
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtGui
 
 from .tabular_base import TabularBase
 

--- a/src/asammdf/gui/widgets/channel_bar_display.py
+++ b/src/asammdf/gui/widgets/channel_bar_display.py
@@ -1,11 +1,7 @@
-import json
-import math
-
 import numpy as np
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from ..dialogs.range_editor import RangeEditor
-from ..ui import resource_rc
 from ..ui.channel_bar_display_widget import Ui_ChannelBarDisplay
 
 

--- a/src/asammdf/gui/widgets/channel_group_info.py
+++ b/src/asammdf/gui/widgets/channel_group_info.py
@@ -3,7 +3,6 @@ import pandas as pd
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from ...blocks.utils import csv_bytearray2hex
-from ..ui import resource_rc
 from ..ui.channel_group_info_widget import Ui_ChannelGroupInfo
 from ..utils import BLUE
 from ..widgets.list_item import ListItem

--- a/src/asammdf/gui/widgets/channel_info.py
+++ b/src/asammdf/gui/widgets/channel_info.py
@@ -1,6 +1,5 @@
 from PySide6 import QtWidgets
 
-from ..ui import resource_rc
 from ..ui.channel_info_widget import Ui_ChannelInfo
 
 

--- a/src/asammdf/gui/widgets/channel_stats.py
+++ b/src/asammdf/gui/widgets/channel_stats.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 import numpy as np
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from ..ui import resource_rc
 from ..ui.channel_stats import Ui_ChannelStats
 
 MONOSPACE_FONT = None

--- a/src/asammdf/gui/widgets/fft_window.py
+++ b/src/asammdf/gui/widgets/fft_window.py
@@ -1,8 +1,7 @@
 import numpy as np
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtWidgets
 import scipy.signal as scipy_signal
 
-from ..ui import resource_rc
 from ..ui.fft_window import Ui_FFTWindow
 from .plot import Plot, PlotSignal, Signal
 

--- a/src/asammdf/gui/widgets/file.py
+++ b/src/asammdf/gui/widgets/file.py
@@ -6,14 +6,11 @@ import os
 from pathlib import Path
 import re
 from tempfile import gettempdir
-from time import sleep
 from traceback import format_exc
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from natsort import natsorted
 import pandas as pd
-import psutil
-import pyqtgraph as pg
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from ... import tool
@@ -44,7 +41,6 @@ from ..dialogs.error_dialog import ErrorDialog
 from ..dialogs.gps_dialog import GPSDialog
 from ..dialogs.messagebox import MessageBox
 from ..dialogs.window_selection_dialog import WindowSelectionDialog
-from ..ui import resource_rc
 from ..ui.file_widget import Ui_file_widget
 from ..utils import GREEN, HelperChannel, run_thread_with_progress, setup_progress
 from .attachment import Attachment

--- a/src/asammdf/gui/widgets/file.py
+++ b/src/asammdf/gui/widgets/file.py
@@ -1269,8 +1269,8 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
 
             progress = setup_progress(
                 parent=self,
-                title=f"Loading display windows",
-                message=f"",
+                title="Loading display windows",
+                message="",
                 icon_name="window",
             )
             progress.setRange(0, count - 1)
@@ -1838,7 +1838,7 @@ MultiRasterSeparator;&
             if call_info["unknown_id_count"]:
                 message.append(f'- {call_info["unknown_id_count"]} unknown IDs in the MDF4 file')
             else:
-                message.append(f"- no unknown IDs inf the MDF4 file")
+                message.append("- no unknown IDs inf the MDF4 file")
 
             message += [
                 "",
@@ -2038,7 +2038,7 @@ MultiRasterSeparator;&
             if call_info["unknown_id_count"]:
                 message.append(f'- {call_info["unknown_id_count"]} unknown IDs in the MDF4 file')
             else:
-                message.append(f"- no unknown IDs inf the MDF4 file")
+                message.append("- no unknown IDs inf the MDF4 file")
 
             message += [
                 "",
@@ -2297,7 +2297,7 @@ MultiRasterSeparator;&
                 try:
                     item.setText(1, f"{self.mdf.file_limit / 1024 / 1024:.1f} MB")
                 except:
-                    item.setText(1, f"Unknown size")
+                    item.setText(1, "Unknown size")
             children.append(item)
 
             if file_stats is not None:

--- a/src/asammdf/gui/widgets/flexray_bus_trace.py
+++ b/src/asammdf/gui/widgets/flexray_bus_trace.py
@@ -1,9 +1,8 @@
-import datetime
 import logging
 
 import dateutil.tz
 import pandas as pd
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtGui
 
 from .tabular_base import TabularBase
 

--- a/src/asammdf/gui/widgets/functions_manager.py
+++ b/src/asammdf/gui/widgets/functions_manager.py
@@ -1,22 +1,17 @@
-import inspect
 import json
 import math
 import os
 from pathlib import Path
-import random
-from traceback import format_exc
 
 from natsort import natsorted
 import numpy as np
 import pandas as pd
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtGui, QtWidgets
 
 from ..dialogs.messagebox import MessageBox
 from ..ui.functions_manager import Ui_FunctionsManager
 from ..utils import (
     check_generated_function,
-    ErrorDialog,
-    FUNC_NAME,
     generate_python_function,
 )
 from .python_highlighter import PythonHighlighter

--- a/src/asammdf/gui/widgets/gps.py
+++ b/src/asammdf/gui/widgets/gps.py
@@ -1,12 +1,10 @@
-import io
-import sys
 from traceback import format_exc
 
 import numpy as np
 from PySide6 import QtCore, QtWidgets
 
 try:
-    from pyqtlet2 import L, leaflet, MapWidget
+    from pyqtlet2 import L, MapWidget
     from PySide6.QtWebEngineCore import QWebEngineSettings
 
 except:
@@ -14,7 +12,6 @@ except:
     pass
 
 
-from ..ui import resource_rc
 from ..ui.gps import Ui_GPSDisplay
 
 

--- a/src/asammdf/gui/widgets/lin_bus_trace.py
+++ b/src/asammdf/gui/widgets/lin_bus_trace.py
@@ -1,9 +1,8 @@
-import datetime
 import logging
 
 import dateutil.tz
 import pandas as pd
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtGui
 
 from .tabular_base import TabularBase
 

--- a/src/asammdf/gui/widgets/list.py
+++ b/src/asammdf/gui/widgets/list.py
@@ -1,6 +1,5 @@
 import json
 from struct import pack
-from traceback import format_exc
 
 from natsort import natsorted
 from PySide6 import QtCore, QtGui, QtWidgets

--- a/src/asammdf/gui/widgets/mdi_area.py
+++ b/src/asammdf/gui/widgets/mdi_area.py
@@ -3,7 +3,6 @@ from functools import partial
 import inspect
 import itertools
 import json
-import math
 import os
 from pathlib import Path
 from random import randint
@@ -37,17 +36,14 @@ from ..utils import (
     computation_to_python_function,
     compute_signal,
     copy_ranges,
-    generate_python_function,
     replace_computation_dependency,
-    VARIABLE,
-    VARIABLE_GET_DATA,
 )
 from .can_bus_trace import CANBusTrace
 from .flexray_bus_trace import FlexRayBusTrace
 from .gps import GPS
 from .lin_bus_trace import LINBusTrace
 from .numeric import Numeric
-from .plot import get_descriptions_by_uuid, Plot
+from .plot import Plot
 from .tabular import Tabular
 
 COMPONENT = re.compile(r"\[(?P<index>\d+)\]$")

--- a/src/asammdf/gui/widgets/numeric.py
+++ b/src/asammdf/gui/widgets/numeric.py
@@ -912,7 +912,7 @@ class HeaderView(QtWidgets.QTableView):
         menu.addAction(self.tr(f"{count} rows in the numeric window"))
         menu.addSeparator()
 
-        menu.addAction(self.tr(f"Automatic set columns width"))
+        menu.addAction(self.tr("Automatic set columns width"))
 
         action = menu.exec_(self.viewport().mapToGlobal(position))
 
@@ -1528,7 +1528,7 @@ class Numeric(Ui_NumericDisplay, QtWidgets.QWidget):
         try:
             target = float(self.target.text().strip())
         except:
-            self.match.setText(f"the target must a numeric value")
+            self.match.setText("the target must a numeric value")
         else:
             if target.is_integer():
                 target = int(target)
@@ -1563,7 +1563,7 @@ class Numeric(Ui_NumericDisplay, QtWidgets.QWidget):
                 self.timestamp.setValue(timestamp)
                 self.match.setText(f"condition found for {signal_name}")
             else:
-                self.match.setText(f"condition not found")
+                self.match.setText("condition not found")
 
     def keyPressEvent(self, event):
         key = event.key()

--- a/src/asammdf/gui/widgets/numeric.py
+++ b/src/asammdf/gui/widgets/numeric.py
@@ -24,7 +24,6 @@ from asammdf.gui.utils import (
 from asammdf.gui.widgets.plot import PlotSignal
 
 from ...blocks.utils import extract_mime_names
-from ..ui import resource_rc
 from ..ui.numeric_offline import Ui_NumericDisplay
 from ..utils import FONT_SIZE
 

--- a/src/asammdf/gui/widgets/plot.py
+++ b/src/asammdf/gui/widgets/plot.py
@@ -1,5 +1,4 @@
 import bisect
-from collections import defaultdict
 from datetime import timedelta
 from functools import lru_cache, partial, reduce
 import os
@@ -20,9 +19,9 @@ PLOT_BUFFER_SIZE = 4000
 
 from ... import tool as Tool
 from ...blocks.conversion_utils import from_dict, to_dict
-from ...blocks.utils import target_byte_order, timeit
+from ...blocks.utils import target_byte_order
 from ..dialogs.messagebox import MessageBox
-from ..utils import BLUE, FONT_SIZE, GREEN, value_as_str
+from ..utils import FONT_SIZE, value_as_str
 from .viewbox import ViewBoxWithCursor
 
 try:

--- a/src/asammdf/gui/widgets/plot.py
+++ b/src/asammdf/gui/widgets/plot.py
@@ -4328,8 +4328,8 @@ class PlotGraphics(pg.PlotWidget):
         if not functions:
             MessageBox.warning(
                 self,
-                f"Cannot add computed channel",
-                f"There is no user defined function. Create new function using the Functions Manger (F6)",
+                "Cannot add computed channel",
+                "There is no user defined function. Create new function using the Functions Manger (F6)",
             )
             return
 
@@ -5894,7 +5894,7 @@ class CursorInfo(QtWidgets.QLabel):
         self.customContextMenuRequested.connect(self.open_menu)
 
         if precision == -1:
-            self.setToolTip(f"Cursor information uses maximum precision")
+            self.setToolTip("Cursor information uses maximum precision")
         else:
             self.setToolTip(f"Cursor information precision is set to {self.precision} decimals")
 
@@ -5974,7 +5974,7 @@ class CursorInfo(QtWidgets.QLabel):
     def set_precision(self, precision):
         self.precision = precision
         if precision == -1:
-            self.setToolTip(f"Cursor information uses maximum precision")
+            self.setToolTip("Cursor information uses maximum precision")
         else:
             self.setToolTip(f"Cursor information precision is set to {precision} decimals")
         self.update_value()

--- a/src/asammdf/gui/widgets/plot_standalone.py
+++ b/src/asammdf/gui/widgets/plot_standalone.py
@@ -5,7 +5,6 @@ import webbrowser
 import pyqtgraph as pg
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from ..ui import resource_rc
 from .plot import Plot, PlotSignal
 
 bin_ = bin

--- a/src/asammdf/gui/widgets/range_widget.py
+++ b/src/asammdf/gui/widgets/range_widget.py
@@ -1,6 +1,5 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from ..ui import resource_rc
 from ..ui.range_widget import Ui_RangeWidget
 
 

--- a/src/asammdf/gui/widgets/search.py
+++ b/src/asammdf/gui/widgets/search.py
@@ -1,6 +1,5 @@
 from PySide6 import QtCore, QtWidgets
 
-from ..ui import resource_rc
 from ..ui.search_widget import Ui_SearchWidget
 
 

--- a/src/asammdf/gui/widgets/signal_scale.py
+++ b/src/asammdf/gui/widgets/signal_scale.py
@@ -5,7 +5,6 @@ import numpy as np
 from pyqtgraph import functions as fn
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from ..ui import resource_rc
 from ..ui.signal_scale import Ui_ScaleDialog
 from ..utils import BLUE
 from .plot import PlotSignal

--- a/src/asammdf/gui/widgets/tabular.py
+++ b/src/asammdf/gui/widgets/tabular.py
@@ -1,21 +1,15 @@
-import datetime
 import logging
-from traceback import format_exc
 
 import dateutil.tz
 import numpy as np
 import numpy.core.defchararray as npchar
 import pandas as pd
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 from ...blocks.utils import (
     csv_bytearray2hex,
-    csv_int2bin,
-    csv_int2hex,
-    pandas_query_compatible,
 )
-from .tabular_base import TabularBase, TabularTreeItem
-from .tabular_filter import TabularFilter
+from .tabular_base import TabularBase
 
 logger = logging.getLogger("asammdf.gui")
 LOCAL_TIMEZONE = dateutil.tz.tzlocal()

--- a/src/asammdf/gui/widgets/tabular_base.py
+++ b/src/asammdf/gui/widgets/tabular_base.py
@@ -47,7 +47,6 @@ from ...blocks.utils import (
 )
 from ...mdf import MDF
 from ..dialogs.range_editor import RangeEditor
-from ..ui import resource_rc
 from ..ui.tabular import Ui_TabularDisplay
 from ..utils import (
     copy_ranges,

--- a/src/asammdf/gui/widgets/tabular_filter.py
+++ b/src/asammdf/gui/widgets/tabular_filter.py
@@ -2,7 +2,6 @@ import pandas as pd
 from PySide6 import QtCore, QtWidgets
 
 from ..dialogs.messagebox import MessageBox
-from ..ui import resource_rc
 from ..ui.tabular_filter import Ui_TabularFilter
 
 

--- a/src/asammdf/gui/widgets/tree.py
+++ b/src/asammdf/gui/widgets/tree.py
@@ -1,9 +1,8 @@
-from datetime import date, datetime
+from datetime import datetime
 from enum import IntFlag
 from functools import lru_cache
 import json
 import os
-import random
 import re
 from traceback import format_exc
 

--- a/src/asammdf/gui/widgets/tree.py
+++ b/src/asammdf/gui/widgets/tree.py
@@ -755,7 +755,7 @@ class ChannelsTreeWidget(QtWidgets.QTreeWidget):
                 ranges = []
                 for item in selected_items:
                     ranges.extend(item.ranges)
-                dlg = RangeEditor(f"<selected items>", ranges=unique_ranges(ranges), parent=self)
+                dlg = RangeEditor("<selected items>", ranges=unique_ranges(ranges), parent=self)
                 dlg.exec_()
                 if dlg.pressed_button == "apply":
                     for item in selected_items:
@@ -887,8 +887,8 @@ class ChannelsTreeWidget(QtWidgets.QTreeWidget):
             menu.addAction(QtGui.QIcon(":/down.png"), f"Find next {item.name}")
         menu.addSeparator()
 
-        menu.addAction(self.tr(f"Add channel group [Shift+Insert]"))
-        menu.addAction(self.tr(f"Add pattern based channel group [Ctrl+Insert]"))
+        menu.addAction(self.tr("Add channel group [Shift+Insert]"))
+        menu.addAction(self.tr("Add pattern based channel group [Ctrl+Insert]"))
         menu.addSeparator()
 
         menu.addAction(self.tr("Copy names [Ctrl+N]"))
@@ -1683,9 +1683,9 @@ class ChannelsTreeItem(QtWidgets.QTreeWidgetItem):
             self.details_text = details or "\tSource not available"
             self.setToolTip(self.NameColumn, tooltip)
             self.setToolTip(self.ValueColumn, "")
-            self.setToolTip(self.UnitColumn, f"unit")
-            self.setToolTip(self.CommonAxisColumn, f"common axis")
-            self.setToolTip(self.IndividualAxisColumn, f"individual axis")
+            self.setToolTip(self.UnitColumn, "unit")
+            self.setToolTip(self.CommonAxisColumn, "common axis")
+            self.setToolTip(self.IndividualAxisColumn, "individual axis")
 
             self.setText(self.UnitColumn, signal.unit)
 

--- a/src/asammdf/gui/widgets/tree_item.py
+++ b/src/asammdf/gui/widgets/tree_item.py
@@ -1,7 +1,6 @@
 from time import perf_counter
-from traceback import format_exc
 
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtWidgets
 
 from ..utils import get_colors_using_ranges
 

--- a/src/asammdf/gui/widgets/vrtt_widget.py
+++ b/src/asammdf/gui/widgets/vrtt_widget.py
@@ -1,7 +1,6 @@
 import numpy as np
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtWidgets
 
-from ..ui import resource_rc
 from ..ui.vrtt_widget import Ui_VRTT_Widget
 
 

--- a/src/asammdf/gui/widgets/vtt_widget.py
+++ b/src/asammdf/gui/widgets/vtt_widget.py
@@ -1,7 +1,6 @@
 import numpy as np
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtWidgets
 
-from ..ui import resource_rc
 from ..ui.vtt_widget import Ui_VTT_Widget
 
 

--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -17,12 +17,11 @@ import os
 from pathlib import Path
 import re
 from shutil import copy, move
-from struct import unpack
 import sys
 from tempfile import gettempdir, mkdtemp
 from traceback import format_exc
 from types import TracebackType
-from typing import Any, overload, Type
+from typing import Any, overload
 from warnings import warn
 import xml.etree.ElementTree as ET
 import zipfile
@@ -34,7 +33,7 @@ import pandas as pd
 from typing_extensions import Literal
 
 from . import tool
-from .blocks import bus_logging_utils, utils
+from .blocks import bus_logging_utils
 from .blocks import v2_v3_constants as v23c
 from .blocks import v4_constants as v4c
 from .blocks.conversion_utils import from_dict
@@ -92,7 +91,6 @@ from .types import (
     StrOrBytesPathType,
     StrPathType,
 )
-from .version import __version__
 
 try:
     import fsspec

--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -1666,7 +1666,7 @@ class MDF:
                         comment = ""
 
                     if comment:
-                        for char in f'\n\t\r\b <>\\/:"?*|':
+                        for char in '\n\t\r\b <>\\/:"?*|':
                             comment = comment.replace(char, "_")
                         group_csv_name = filename.parent / f"{filename.stem}.ChannelGroup_{i}_{comment}.csv"
                     else:

--- a/test/asammdf/gui/dialogs/test_FunctionsManagerDialog.py
+++ b/test/asammdf/gui/dialogs/test_FunctionsManagerDialog.py
@@ -220,7 +220,7 @@ class TestPushButtons(TestBase):
 
         # Evaluate
         self.assertTrue(saved_file.exists())
-        with open(saved_file, "r") as fpr:
+        with open(saved_file) as fpr:
             content = json.load(fpr)
             self.assertDictEqual(content, {"Function1": "def Function1(t=0):\n    return 0"})
 
@@ -328,7 +328,7 @@ class TestPushButtons(TestBase):
 
         # Evaluate
         self.assertTrue(saved_file.exists())
-        with open(saved_file, "r") as fpr:
+        with open(saved_file) as fpr:
             content = json.load(fpr)
             self.assertIn(maximum.__name__, content)
             self.assertIn(content["maximum"], source)

--- a/test/asammdf/gui/test_util.py
+++ b/test/asammdf/gui/test_util.py
@@ -90,7 +90,7 @@ class TestUtils(unittest.TestCase):
             - Evaluate trace. (position 1)
         """
         # Event
-        result = generate_python_function(rf"def Function1(t=0):\n    return true", None)
+        result = generate_python_function(r"def Function1(t=0):\n    return true", None)
 
         # Evaluate
         self.assertIsInstance(result, tuple)
@@ -113,7 +113,7 @@ class TestUtils(unittest.TestCase):
             trace = 'The last function argument must be "t=0"'
 
             # Event
-            result = generate_python_function(f"def Function1():\n\treturn 0", None)
+            result = generate_python_function("def Function1():\n\treturn 0", None)
 
             # Evaluate
             self.assertIsInstance(result, tuple)
@@ -124,7 +124,7 @@ class TestUtils(unittest.TestCase):
             trace = 'The last function argument must be "t=0"'
 
             # Event
-            result = generate_python_function(f"def Function1(t=0, x=0):\n\treturn 0", None)
+            result = generate_python_function("def Function1(t=0, x=0):\n\treturn 0", None)
 
             # Evaluate
             self.assertIsInstance(result, tuple)
@@ -135,7 +135,7 @@ class TestUtils(unittest.TestCase):
             trace = 'The last function argument must be "t=0"'
 
             # Event
-            result = generate_python_function(f"def Function1(t=1):\n\treturn 0", None)
+            result = generate_python_function("def Function1(t=1):\n\treturn 0", None)
 
             # Evaluate
             self.assertIsInstance(result, tuple)
@@ -146,7 +146,7 @@ class TestUtils(unittest.TestCase):
             trace = 'All the arguments must have default values. The argument "channel" has no default value.'
 
             # Event
-            result = generate_python_function(f"def Function1(channel, t=0):\n\treturn 0", None)
+            result = generate_python_function("def Function1(channel, t=0):\n\treturn 0", None)
 
             # Evaluate
             self.assertIsInstance(result, tuple)
@@ -164,7 +164,7 @@ class TestUtils(unittest.TestCase):
         """
         with self.subTest(f"{self.id()}_0"):
             # Event
-            result = generate_python_function(f"def Function1(t=0):\n\treturn 0", None)
+            result = generate_python_function("def Function1(t=0):\n\treturn 0", None)
 
             # Evaluate
             self.assertIsInstance(result, tuple)

--- a/test/asammdf/gui/test_util.py
+++ b/test/asammdf/gui/test_util.py
@@ -1,12 +1,9 @@
 import inspect
 from test.asammdf.gui.resources.functions import (
     Function1,
-    Function2,
     gray2dec,
     maximum,
     rpm_to_rad_per_second,
-    UnresolvedVariable,
-    WrongDefinition,
 )
 import unittest
 

--- a/test/test_endianess.py
+++ b/test/test_endianess.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from pathlib import Path
-import shutil
 import tempfile
 import unittest
 

--- a/test/test_endianess.py
+++ b/test/test_endianess.py
@@ -28,7 +28,7 @@ class TestEndianess(unittest.TestCase):
         for version in ("3.30", "4.10"):
             mdf = MDF(version=version)
             mdf.append([s1, s2], common_timebase=True)
-            outfile = mdf.save(Path(TestEndianess.tempdir.name) / f"out", overwrite=True)
+            outfile = mdf.save(Path(TestEndianess.tempdir.name) / "out", overwrite=True)
             mdf.close()
 
             with MDF(outfile) as mdf:
@@ -38,7 +38,7 @@ class TestEndianess(unittest.TestCase):
         for version in ("3.30", "4.10"):
             mdf = MDF(version=version)
             mdf.append([s2, s1], common_timebase=True)
-            outfile = mdf.save(Path(TestEndianess.tempdir.name) / f"out", overwrite=True)
+            outfile = mdf.save(Path(TestEndianess.tempdir.name) / "out", overwrite=True)
             mdf.close()
 
             with MDF(outfile) as mdf:
@@ -73,7 +73,7 @@ class TestEndianess(unittest.TestCase):
             ch4.data_type = v23c.DATA_TYPE_UNSIGNED_INTEL
             ch4.bit_count = 16
 
-            outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / f"out", overwrite=True)
+            outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / "out", overwrite=True)
 
             with MDF(outfile) as mdf:
                 assert np.array_equal(mdf.get("NotAlignedMotorola").samples, [0x0204] * 15)
@@ -89,7 +89,7 @@ class TestEndianess(unittest.TestCase):
             ch4.data_type = v23c.DATA_TYPE_UNSIGNED_INTEL
             ch4.bit_count = 24
 
-            outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / f"out", overwrite=True)
+            outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / "out", overwrite=True)
 
             with MDF(outfile) as mdf:
                 assert np.array_equal(mdf.get("NotAlignedMotorola").samples, [0x3F0204] * 15)
@@ -106,7 +106,7 @@ class TestEndianess(unittest.TestCase):
             ch4.data_type = v23c.DATA_TYPE_UNSIGNED_INTEL
             ch4.bit_count = 21
 
-            outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / f"out", overwrite=True)
+            outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / "out", overwrite=True)
 
             with MDF(outfile) as mdf:
                 assert np.array_equal(
@@ -147,7 +147,7 @@ class TestEndianess(unittest.TestCase):
             ch4.data_type = v4c.DATA_TYPE_UNSIGNED_INTEL
             ch4.bit_count = 16
 
-            outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / f"out", overwrite=True)
+            outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / "out", overwrite=True)
 
             with MDF(outfile) as mdf:
                 assert np.array_equal(mdf.get("NotAlignedMotorola").samples, [0x0204] * 15)
@@ -164,7 +164,7 @@ class TestEndianess(unittest.TestCase):
             ch4.data_type = v4c.DATA_TYPE_UNSIGNED_INTEL
             ch4.bit_count = 24
 
-            outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / f"out", overwrite=True)
+            outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / "out", overwrite=True)
 
             with MDF(outfile) as mdf:
                 assert np.array_equal(mdf.get("NotAlignedMotorola").samples, [0x3F0204] * 15)
@@ -183,7 +183,7 @@ class TestEndianess(unittest.TestCase):
             ch4.bit_count = 21
             ch4.bit_offset = 6
 
-            outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / f"out", overwrite=True)
+            outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / "out", overwrite=True)
 
             with MDF(outfile) as mdf:
                 assert np.array_equal(
@@ -241,7 +241,7 @@ class TestEndianess(unittest.TestCase):
                 ch4.data_type = v23c.DATA_TYPE_UNSIGNED_INTEL
                 ch4.bit_count = 16
 
-                outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / f"out", overwrite=True)
+                outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / "out", overwrite=True)
 
                 with MDF(outfile) as mdf:
                     assert np.array_equal(mdf.get("OverlappingMotorola").samples, [0x0204] * 15)
@@ -258,7 +258,7 @@ class TestEndianess(unittest.TestCase):
                 ch4.data_type = v23c.DATA_TYPE_UNSIGNED_INTEL
                 ch4.bit_count = 24
 
-                outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / f"out", overwrite=True)
+                outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / "out", overwrite=True)
 
                 with MDF(outfile) as mdf:
                     assert np.array_equal(mdf.get("OverlappingMotorola").samples, [0x3F0204] * 15)
@@ -275,7 +275,7 @@ class TestEndianess(unittest.TestCase):
                 ch4.data_type = v23c.DATA_TYPE_UNSIGNED_INTEL
                 ch4.bit_count = 21
 
-                outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / f"out", overwrite=True)
+                outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / "out", overwrite=True)
 
                 with MDF(outfile) as mdf:
                     assert np.array_equal(
@@ -335,7 +335,7 @@ class TestEndianess(unittest.TestCase):
                 ch4.bit_count = 16
                 ch4.bit_offset = 0
 
-                outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / f"out", overwrite=True)
+                outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / "out", overwrite=True)
 
                 with MDF(outfile) as mdf:
                     assert np.array_equal(mdf.get("OverlappingMotorola").samples, [0x0204] * 15)
@@ -354,7 +354,7 @@ class TestEndianess(unittest.TestCase):
                 ch4.bit_count = 24
                 ch4.bit_offset = 0
 
-                outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / f"out", overwrite=True)
+                outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / "out", overwrite=True)
 
                 with MDF(outfile) as mdf:
                     assert np.array_equal(mdf.get("OverlappingMotorola").samples, [0x3F0204] * 15)
@@ -373,7 +373,7 @@ class TestEndianess(unittest.TestCase):
                 ch4.bit_count = 21
                 ch4.bit_offset = 6
 
-                outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / f"out", overwrite=True)
+                outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / "out", overwrite=True)
 
                 with MDF(outfile) as mdf:
                     assert np.array_equal(
@@ -398,7 +398,7 @@ class TestEndianess(unittest.TestCase):
                 ch4.bit_count = 2
                 ch4.bit_offset = 1
 
-                outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / f"out", overwrite=True)
+                outfile = mdf_source.save(Path(TestEndianess.tempdir.name) / "out", overwrite=True)
 
                 with MDF(outfile) as mdf:
                     assert np.array_equal(mdf.get("OverlappingMotorola").samples, [0x1] * 15)

--- a/test/test_mdf.py
+++ b/test/test_mdf.py
@@ -105,9 +105,7 @@ class TestMDF(unittest.TestCase):
                                     equal = False
                         elif i == 4:
                             for j in range(1, 20):
-                                target = np.array(
-                                    ["Channel {} sample {}".format(j, k).encode("ascii") for k in range(cycles)]
-                                )
+                                target = np.array([f"Channel {j} sample {k}".encode("ascii") for k in range(cycles)])
                                 vals = mdf.get(group=i, index=j + 1, samples_only=True)[0]
                                 cond = np.array_equal(vals, target)
                                 if not cond:
@@ -158,13 +156,13 @@ class TestMDF(unittest.TestCase):
 
                             for j in range(1, 20):
                                 types = [
-                                    ("Channel_{}".format(j), "(2, 3)<u8"),
-                                    ("channel_{}_axis_1".format(j), "(2, )<u8"),
-                                    ("channel_{}_axis_2".format(j), "(3, )<u8"),
+                                    (f"Channel_{j}", "(2, 3)<u8"),
+                                    (f"channel_{j}_axis_1", "(2, )<u8"),
+                                    (f"channel_{j}_axis_2", "(3, )<u8"),
                                 ]
                                 types = np.dtype(types)
 
-                                vals = mdf.get("Channel_{}".format(j), group=i, samples_only=True)[0]
+                                vals = mdf.get(f"Channel_{j}", group=i, samples_only=True)[0]
                                 target = [arr * j for arr in samples]
                                 target = np.core.records.fromarrays(target, dtype=types)
                                 if not np.array_equal(vals, target):
@@ -177,10 +175,10 @@ class TestMDF(unittest.TestCase):
                             axis_1 = np.ones((cycles, 3), dtype=np.uint64)
 
                             for j in range(1, 20):
-                                types = [("Channel_{}".format(j), "(2, 3)<u8")]
+                                types = [(f"Channel_{j}", "(2, 3)<u8")]
                                 types = np.dtype(types)
 
-                                vals = mdf.get("Channel_{}".format(j), group=i, samples_only=True)[0]
+                                vals = mdf.get(f"Channel_{j}", group=i, samples_only=True)[0]
                                 target = [samples * j]
                                 target = np.core.records.fromarrays(target, dtype=types)
                                 if not np.array_equal(vals, target):
@@ -201,18 +199,18 @@ class TestMDF(unittest.TestCase):
 
                             for j in range(1, 20):
                                 types = [
-                                    ("struct_{}_channel_0".format(j), np.uint8),
-                                    ("struct_{}_channel_1".format(j), np.uint16),
-                                    ("struct_{}_channel_2".format(j), np.uint32),
-                                    ("struct_{}_channel_3".format(j), np.uint64),
-                                    ("struct_{}_channel_4".format(j), np.int8),
-                                    ("struct_{}_channel_5".format(j), np.int16),
-                                    ("struct_{}_channel_6".format(j), np.int32),
-                                    ("struct_{}_channel_7".format(j), np.int64),
+                                    (f"struct_{j}_channel_0", np.uint8),
+                                    (f"struct_{j}_channel_1", np.uint16),
+                                    (f"struct_{j}_channel_2", np.uint32),
+                                    (f"struct_{j}_channel_3", np.uint64),
+                                    (f"struct_{j}_channel_4", np.int8),
+                                    (f"struct_{j}_channel_5", np.int16),
+                                    (f"struct_{j}_channel_6", np.int32),
+                                    (f"struct_{j}_channel_7", np.int64),
                                 ]
                                 types = np.dtype(types)
 
-                                vals = mdf.get("Channel_{}".format(j), group=i, samples_only=True)[0]
+                                vals = mdf.get(f"Channel_{j}", group=i, samples_only=True)[0]
                                 target = [arr * j for arr in samples]
                                 target = np.core.records.fromarrays(target, dtype=types)
                                 if not np.array_equal(vals, target):
@@ -313,7 +311,7 @@ class TestMDF(unittest.TestCase):
                             elif i == 4:
                                 for j in range(1, 20):
                                     target = np.array(
-                                        ["Channel {} sample {}".format(j, k).encode("ascii") for k in range(cycles)]
+                                        [f"Channel {j} sample {k}".encode("ascii") for k in range(cycles)]
                                     )
                                     vals = mdf.get(group=i, index=j + 1, samples_only=True)[0]
                                     cond = np.array_equal(vals, target)
@@ -463,7 +461,7 @@ class TestMDF(unittest.TestCase):
                             elif i == 4:
                                 for j in range(1, 20):
                                     target = np.array(
-                                        ["Channel {} sample {}".format(j, k).encode("ascii") for k in range(cycles)]
+                                        [f"Channel {j} sample {k}".encode("ascii") for k in range(cycles)]
                                     )
                                     vals = mdf.get(group=i, index=j + 1, samples_only=True)[0]
                                     cond = np.array_equal(vals, target)
@@ -532,13 +530,13 @@ class TestMDF(unittest.TestCase):
 
                             for j in range(1, 20):
                                 types = [
-                                    ("Channel_{}".format(j), "(2, 3)<u8"),
-                                    ("channel_{}_axis_1".format(j), "(2, )<u8"),
-                                    ("channel_{}_axis_2".format(j), "(3, )<u8"),
+                                    (f"Channel_{j}", "(2, 3)<u8"),
+                                    (f"channel_{j}_axis_1", "(2, )<u8"),
+                                    (f"channel_{j}_axis_2", "(3, )<u8"),
                                 ]
                                 types = np.dtype(types)
 
-                                vals = mdf.get("Channel_{}".format(j), group=i, samples_only=True)[0]
+                                vals = mdf.get(f"Channel_{j}", group=i, samples_only=True)[0]
                                 target = [arr * j for arr in samples]
                                 target = np.core.records.fromarrays(target, dtype=types)
                                 if not np.array_equal(vals, target):
@@ -560,10 +558,10 @@ class TestMDF(unittest.TestCase):
                             axis_1 = np.ones((cycles, 3), dtype=np.uint64)
 
                             for j in range(1, 20):
-                                types = [("Channel_{}".format(j), "(2, 3)<u8")]
+                                types = [(f"Channel_{j}", "(2, 3)<u8")]
                                 types = np.dtype(types)
 
-                                vals = mdf.get("Channel_{}".format(j), group=i, samples_only=True)[0]
+                                vals = mdf.get(f"Channel_{j}", group=i, samples_only=True)[0]
                                 target = [samples * j]
                                 target = np.core.records.fromarrays(target, dtype=types)
                                 if not np.array_equal(vals, target):
@@ -584,18 +582,18 @@ class TestMDF(unittest.TestCase):
 
                             for j in range(1, 20):
                                 types = [
-                                    ("struct_{}_channel_0".format(j), np.uint8),
-                                    ("struct_{}_channel_1".format(j), np.uint16),
-                                    ("struct_{}_channel_2".format(j), np.uint32),
-                                    ("struct_{}_channel_3".format(j), np.uint64),
-                                    ("struct_{}_channel_4".format(j), np.int8),
-                                    ("struct_{}_channel_5".format(j), np.int16),
-                                    ("struct_{}_channel_6".format(j), np.int32),
-                                    ("struct_{}_channel_7".format(j), np.int64),
+                                    (f"struct_{j}_channel_0", np.uint8),
+                                    (f"struct_{j}_channel_1", np.uint16),
+                                    (f"struct_{j}_channel_2", np.uint32),
+                                    (f"struct_{j}_channel_3", np.uint64),
+                                    (f"struct_{j}_channel_4", np.int8),
+                                    (f"struct_{j}_channel_5", np.int16),
+                                    (f"struct_{j}_channel_6", np.int32),
+                                    (f"struct_{j}_channel_7", np.int64),
                                 ]
                                 types = np.dtype(types)
 
-                                vals = mdf.get("Channel_{}".format(j), group=i, samples_only=True)[0]
+                                vals = mdf.get(f"Channel_{j}", group=i, samples_only=True)[0]
                                 target = [arr * j for arr in samples]
                                 target = np.core.records.fromarrays(target, dtype=types)
                                 if not np.array_equal(vals, target):

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from pathlib import Path
 
 import numpy as np
@@ -44,10 +43,10 @@ def generate_test_file(tmpdir, version="4.10"):
         sig = Signal(
             np.ones(cycles, dtype=np.uint64) * i,
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
             conversion=None,
-            comment="Unsigned int 16bit channel {}".format(i),
+            comment=f"Unsigned int 16bit channel {i}",
             raw=True,
         )
         sigs.append(sig)
@@ -64,10 +63,10 @@ def generate_test_file(tmpdir, version="4.10"):
         sig = Signal(
             np.ones(cycles, dtype=np.int64),
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
             conversion=cls(**conversion),
-            comment="Signed 16bit channel {} with linear conversion".format(i),
+            comment=f"Signed 16bit channel {i} with linear conversion",
             raw=True,
         )
         sigs.append(sig)
@@ -78,15 +77,15 @@ def generate_test_file(tmpdir, version="4.10"):
     for i in range(channels_count):
         conversion = {
             "conversion_type": v4c.CONVERSION_TYPE_ALG if version >= "4.00" else v3c.CONVERSION_TYPE_FORMULA,
-            "formula": "{} * sin(X)".format(i),
+            "formula": f"{i} * sin(X)",
         }
         sig = Signal(
             np.arange(cycles, dtype=np.int32) / 100.0,
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
             conversion=cls(**conversion),
-            comment="Sinus channel {} with algebraic conversion".format(i),
+            comment=f"Sinus channel {i} with algebraic conversion",
             raw=True,
         )
         sigs.append(sig)
@@ -107,10 +106,10 @@ def generate_test_file(tmpdir, version="4.10"):
         sig = Signal(
             np.ones(cycles, dtype=np.int64),
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
             conversion=cls(**conversion),
-            comment="Channel {} with rational conversion".format(i),
+            comment=f"Channel {i} with rational conversion",
             raw=True,
         )
         sigs.append(sig)
@@ -120,13 +119,13 @@ def generate_test_file(tmpdir, version="4.10"):
     sigs = []
     encoding = "latin-1" if version < "4.00" else "utf-8"
     for i in range(channels_count):
-        sig = ["Channel {} sample {}".format(i, j).encode(encoding) for j in range(cycles)]
+        sig = [f"Channel {i} sample {j}".encode(encoding) for j in range(cycles)]
         sig = Signal(
             np.array(sig),
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
-            comment="String channel {}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
+            comment=f"String channel {i}",
             raw=True,
             encoding=encoding,
         )
@@ -140,9 +139,9 @@ def generate_test_file(tmpdir, version="4.10"):
         sig = Signal(
             ones * i,
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
-            comment="Byte array channel {}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
+            comment=f"Byte array channel {i}",
             raw=True,
         )
         sigs.append(sig)
@@ -153,24 +152,24 @@ def generate_test_file(tmpdir, version="4.10"):
     ones = np.ones(cycles, dtype=np.uint64)
     conversion = {
         "raw": np.arange(255, dtype=np.float64),
-        "phys": np.array(["Value {}".format(i).encode("ascii") for i in range(255)]),
+        "phys": np.array([f"Value {i}".encode("ascii") for i in range(255)]),
         "conversion_type": v4c.CONVERSION_TYPE_TABX if version >= "4.00" else v3c.CONVERSION_TYPE_TABX,
         "links_nr": 260,
         "ref_param_nr": 255,
     }
 
     for i in range(255):
-        conversion["val_{}".format(i)] = conversion["param_val_{}".format(i)] = conversion["raw"][i]
-        conversion["text_{}".format(i)] = conversion["phys"][i]
-    conversion["text_{}".format(255)] = "Default"
+        conversion[f"val_{i}"] = conversion[f"param_val_{i}"] = conversion["raw"][i]
+        conversion[f"text_{i}"] = conversion["phys"][i]
+    conversion[f"text_{255}"] = "Default"
 
     for i in range(channels_count):
         sig = Signal(
             ones * i,
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
-            comment="Value to text channel {}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
+            comment=f"Value to text channel {i}",
             conversion=cls(**conversion),
             raw=True,
         )
@@ -201,18 +200,18 @@ def generate_arrays_test_file(tmpdir):
         ]
 
         types = [
-            ("Channel_{}".format(i), "(2, 3)<u8"),
-            ("channel_{}_axis_1".format(i), "(2, )<u8"),
-            ("channel_{}_axis_2".format(i), "(3, )<u8"),
+            (f"Channel_{i}", "(2, 3)<u8"),
+            (f"channel_{i}_axis_1", "(2, )<u8"),
+            (f"channel_{i}_axis_2", "(3, )<u8"),
         ]
 
         sig = Signal(
             np.core.records.fromarrays(samples, dtype=np.dtype(types)),
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
             conversion=None,
-            comment="Array channel {}".format(i),
+            comment=f"Array channel {i}",
             raw=True,
         )
         sigs.append(sig)
@@ -223,15 +222,15 @@ def generate_arrays_test_file(tmpdir):
     for i in range(array_channels_count):
         samples = [np.ones((cycles, 2, 3), dtype=np.uint64) * i]
 
-        types = [("Channel_{}".format(i), "(2, 3)<u8")]
+        types = [(f"Channel_{i}", "(2, 3)<u8")]
 
         sig = Signal(
             np.core.records.fromarrays(samples, dtype=np.dtype(types)),
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
             conversion=None,
-            comment="Array channel {} with default axis".format(i),
+            comment=f"Array channel {i} with default axis",
             raw=True,
         )
         sigs.append(sig)
@@ -252,23 +251,23 @@ def generate_arrays_test_file(tmpdir):
         ]
 
         types = [
-            ("struct_{}_channel_0".format(i), np.uint8),
-            ("struct_{}_channel_1".format(i), np.uint16),
-            ("struct_{}_channel_2".format(i), np.uint32),
-            ("struct_{}_channel_3".format(i), np.uint64),
-            ("struct_{}_channel_4".format(i), np.int8),
-            ("struct_{}_channel_5".format(i), np.int16),
-            ("struct_{}_channel_6".format(i), np.int32),
-            ("struct_{}_channel_7".format(i), np.int64),
+            (f"struct_{i}_channel_0", np.uint8),
+            (f"struct_{i}_channel_1", np.uint16),
+            (f"struct_{i}_channel_2", np.uint32),
+            (f"struct_{i}_channel_3", np.uint64),
+            (f"struct_{i}_channel_4", np.int8),
+            (f"struct_{i}_channel_5", np.int16),
+            (f"struct_{i}_channel_6", np.int32),
+            (f"struct_{i}_channel_7", np.int64),
         ]
 
         sig = Signal(
             np.core.records.fromarrays(samples, dtype=np.dtype(types)),
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
             conversion=None,
-            comment="Structure channel composition {}".format(i),
+            comment=f"Structure channel composition {i}",
             raw=True,
         )
         sigs.append(sig)


### PR DESCRIPTION
@danielhrisca  I added a few rules to "ignore", could you take a look at those and push fixes to this PR?

- "F821",  # undefined-name:  
  - 5 occurrences,  these are obvious bugs which must be fixed

- "F401",  # unused-import
  - 15 occurrences, ruff suggests to `consider importlib.util.find_spec to test for availability`

- "F841",  # unused-variable
  - 53 occurrences, these could just be removed, but maybe you left them for informational purposes. These could be fixed with a `_` prefix