### PR TITLE
unnecessary print statement removed

### DIFF
--- a/src/asammdf/signal.py
+++ b/src/asammdf/signal.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Iterator
 import logging
 from textwrap import fill
-from traceback import format_exc
 from typing import Any
 
 import numpy as np

--- a/src/asammdf/signal.py
+++ b/src/asammdf/signal.py
@@ -224,7 +224,6 @@ class Signal:
             return
 
         except:
-            print(format_exc())
             try:
                 import matplotlib.pyplot as plt
                 from matplotlib.widgets import Slider

--- a/test/asammdf/gui/dialogs/test_FunctionsManagerDialog.py
+++ b/test/asammdf/gui/dialogs/test_FunctionsManagerDialog.py
@@ -220,7 +220,7 @@ class TestPushButtons(TestBase):
 
         # Evaluate
         self.assertTrue(saved_file.exists())
-        with open(saved_file, "r") as fpr:
+        with open(saved_file) as fpr:
             content = json.load(fpr)
             self.assertDictEqual(content, {"Function1": "def Function1(t=0):\n    return 0"})
 
@@ -328,7 +328,7 @@ class TestPushButtons(TestBase):
 
         # Evaluate
         self.assertTrue(saved_file.exists())
-        with open(saved_file, "r") as fpr:
+        with open(saved_file) as fpr:
             content = json.load(fpr)
             self.assertIn(maximum.__name__, content)
             self.assertIn(content["maximum"], source)

--- a/test/test_mdf.py
+++ b/test/test_mdf.py
@@ -105,9 +105,7 @@ class TestMDF(unittest.TestCase):
                                     equal = False
                         elif i == 4:
                             for j in range(1, 20):
-                                target = np.array(
-                                    ["Channel {} sample {}".format(j, k).encode("ascii") for k in range(cycles)]
-                                )
+                                target = np.array([f"Channel {j} sample {k}".encode("ascii") for k in range(cycles)])
                                 vals = mdf.get(group=i, index=j + 1, samples_only=True)[0]
                                 cond = np.array_equal(vals, target)
                                 if not cond:
@@ -158,13 +156,13 @@ class TestMDF(unittest.TestCase):
 
                             for j in range(1, 20):
                                 types = [
-                                    ("Channel_{}".format(j), "(2, 3)<u8"),
-                                    ("channel_{}_axis_1".format(j), "(2, )<u8"),
-                                    ("channel_{}_axis_2".format(j), "(3, )<u8"),
+                                    (f"Channel_{j}", "(2, 3)<u8"),
+                                    (f"channel_{j}_axis_1", "(2, )<u8"),
+                                    (f"channel_{j}_axis_2", "(3, )<u8"),
                                 ]
                                 types = np.dtype(types)
 
-                                vals = mdf.get("Channel_{}".format(j), group=i, samples_only=True)[0]
+                                vals = mdf.get(f"Channel_{j}", group=i, samples_only=True)[0]
                                 target = [arr * j for arr in samples]
                                 target = np.core.records.fromarrays(target, dtype=types)
                                 if not np.array_equal(vals, target):
@@ -177,10 +175,10 @@ class TestMDF(unittest.TestCase):
                             axis_1 = np.ones((cycles, 3), dtype=np.uint64)
 
                             for j in range(1, 20):
-                                types = [("Channel_{}".format(j), "(2, 3)<u8")]
+                                types = [(f"Channel_{j}", "(2, 3)<u8")]
                                 types = np.dtype(types)
 
-                                vals = mdf.get("Channel_{}".format(j), group=i, samples_only=True)[0]
+                                vals = mdf.get(f"Channel_{j}", group=i, samples_only=True)[0]
                                 target = [samples * j]
                                 target = np.core.records.fromarrays(target, dtype=types)
                                 if not np.array_equal(vals, target):
@@ -201,18 +199,18 @@ class TestMDF(unittest.TestCase):
 
                             for j in range(1, 20):
                                 types = [
-                                    ("struct_{}_channel_0".format(j), np.uint8),
-                                    ("struct_{}_channel_1".format(j), np.uint16),
-                                    ("struct_{}_channel_2".format(j), np.uint32),
-                                    ("struct_{}_channel_3".format(j), np.uint64),
-                                    ("struct_{}_channel_4".format(j), np.int8),
-                                    ("struct_{}_channel_5".format(j), np.int16),
-                                    ("struct_{}_channel_6".format(j), np.int32),
-                                    ("struct_{}_channel_7".format(j), np.int64),
+                                    (f"struct_{j}_channel_0", np.uint8),
+                                    (f"struct_{j}_channel_1", np.uint16),
+                                    (f"struct_{j}_channel_2", np.uint32),
+                                    (f"struct_{j}_channel_3", np.uint64),
+                                    (f"struct_{j}_channel_4", np.int8),
+                                    (f"struct_{j}_channel_5", np.int16),
+                                    (f"struct_{j}_channel_6", np.int32),
+                                    (f"struct_{j}_channel_7", np.int64),
                                 ]
                                 types = np.dtype(types)
 
-                                vals = mdf.get("Channel_{}".format(j), group=i, samples_only=True)[0]
+                                vals = mdf.get(f"Channel_{j}", group=i, samples_only=True)[0]
                                 target = [arr * j for arr in samples]
                                 target = np.core.records.fromarrays(target, dtype=types)
                                 if not np.array_equal(vals, target):
@@ -313,7 +311,7 @@ class TestMDF(unittest.TestCase):
                             elif i == 4:
                                 for j in range(1, 20):
                                     target = np.array(
-                                        ["Channel {} sample {}".format(j, k).encode("ascii") for k in range(cycles)]
+                                        [f"Channel {j} sample {k}".encode("ascii") for k in range(cycles)]
                                     )
                                     vals = mdf.get(group=i, index=j + 1, samples_only=True)[0]
                                     cond = np.array_equal(vals, target)
@@ -463,7 +461,7 @@ class TestMDF(unittest.TestCase):
                             elif i == 4:
                                 for j in range(1, 20):
                                     target = np.array(
-                                        ["Channel {} sample {}".format(j, k).encode("ascii") for k in range(cycles)]
+                                        [f"Channel {j} sample {k}".encode("ascii") for k in range(cycles)]
                                     )
                                     vals = mdf.get(group=i, index=j + 1, samples_only=True)[0]
                                     cond = np.array_equal(vals, target)
@@ -532,13 +530,13 @@ class TestMDF(unittest.TestCase):
 
                             for j in range(1, 20):
                                 types = [
-                                    ("Channel_{}".format(j), "(2, 3)<u8"),
-                                    ("channel_{}_axis_1".format(j), "(2, )<u8"),
-                                    ("channel_{}_axis_2".format(j), "(3, )<u8"),
+                                    (f"Channel_{j}", "(2, 3)<u8"),
+                                    (f"channel_{j}_axis_1", "(2, )<u8"),
+                                    (f"channel_{j}_axis_2", "(3, )<u8"),
                                 ]
                                 types = np.dtype(types)
 
-                                vals = mdf.get("Channel_{}".format(j), group=i, samples_only=True)[0]
+                                vals = mdf.get(f"Channel_{j}", group=i, samples_only=True)[0]
                                 target = [arr * j for arr in samples]
                                 target = np.core.records.fromarrays(target, dtype=types)
                                 if not np.array_equal(vals, target):
@@ -560,10 +558,10 @@ class TestMDF(unittest.TestCase):
                             axis_1 = np.ones((cycles, 3), dtype=np.uint64)
 
                             for j in range(1, 20):
-                                types = [("Channel_{}".format(j), "(2, 3)<u8")]
+                                types = [(f"Channel_{j}", "(2, 3)<u8")]
                                 types = np.dtype(types)
 
-                                vals = mdf.get("Channel_{}".format(j), group=i, samples_only=True)[0]
+                                vals = mdf.get(f"Channel_{j}", group=i, samples_only=True)[0]
                                 target = [samples * j]
                                 target = np.core.records.fromarrays(target, dtype=types)
                                 if not np.array_equal(vals, target):
@@ -584,18 +582,18 @@ class TestMDF(unittest.TestCase):
 
                             for j in range(1, 20):
                                 types = [
-                                    ("struct_{}_channel_0".format(j), np.uint8),
-                                    ("struct_{}_channel_1".format(j), np.uint16),
-                                    ("struct_{}_channel_2".format(j), np.uint32),
-                                    ("struct_{}_channel_3".format(j), np.uint64),
-                                    ("struct_{}_channel_4".format(j), np.int8),
-                                    ("struct_{}_channel_5".format(j), np.int16),
-                                    ("struct_{}_channel_6".format(j), np.int32),
-                                    ("struct_{}_channel_7".format(j), np.int64),
+                                    (f"struct_{j}_channel_0", np.uint8),
+                                    (f"struct_{j}_channel_1", np.uint16),
+                                    (f"struct_{j}_channel_2", np.uint32),
+                                    (f"struct_{j}_channel_3", np.uint64),
+                                    (f"struct_{j}_channel_4", np.int8),
+                                    (f"struct_{j}_channel_5", np.int16),
+                                    (f"struct_{j}_channel_6", np.int32),
+                                    (f"struct_{j}_channel_7", np.int64),
                                 ]
                                 types = np.dtype(types)
 
-                                vals = mdf.get("Channel_{}".format(j), group=i, samples_only=True)[0]
+                                vals = mdf.get(f"Channel_{j}", group=i, samples_only=True)[0]
                                 target = [arr * j for arr in samples]
                                 target = np.core.records.fromarrays(target, dtype=types)
                                 if not np.array_equal(vals, target):

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from pathlib import Path
 
 import numpy as np
@@ -44,10 +43,10 @@ def generate_test_file(tmpdir, version="4.10"):
         sig = Signal(
             np.ones(cycles, dtype=np.uint64) * i,
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
             conversion=None,
-            comment="Unsigned int 16bit channel {}".format(i),
+            comment=f"Unsigned int 16bit channel {i}",
             raw=True,
         )
         sigs.append(sig)
@@ -64,10 +63,10 @@ def generate_test_file(tmpdir, version="4.10"):
         sig = Signal(
             np.ones(cycles, dtype=np.int64),
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
             conversion=cls(**conversion),
-            comment="Signed 16bit channel {} with linear conversion".format(i),
+            comment=f"Signed 16bit channel {i} with linear conversion",
             raw=True,
         )
         sigs.append(sig)
@@ -78,15 +77,15 @@ def generate_test_file(tmpdir, version="4.10"):
     for i in range(channels_count):
         conversion = {
             "conversion_type": v4c.CONVERSION_TYPE_ALG if version >= "4.00" else v3c.CONVERSION_TYPE_FORMULA,
-            "formula": "{} * sin(X)".format(i),
+            "formula": f"{i} * sin(X)",
         }
         sig = Signal(
             np.arange(cycles, dtype=np.int32) / 100.0,
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
             conversion=cls(**conversion),
-            comment="Sinus channel {} with algebraic conversion".format(i),
+            comment=f"Sinus channel {i} with algebraic conversion",
             raw=True,
         )
         sigs.append(sig)
@@ -107,10 +106,10 @@ def generate_test_file(tmpdir, version="4.10"):
         sig = Signal(
             np.ones(cycles, dtype=np.int64),
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
             conversion=cls(**conversion),
-            comment="Channel {} with rational conversion".format(i),
+            comment=f"Channel {i} with rational conversion",
             raw=True,
         )
         sigs.append(sig)
@@ -120,13 +119,13 @@ def generate_test_file(tmpdir, version="4.10"):
     sigs = []
     encoding = "latin-1" if version < "4.00" else "utf-8"
     for i in range(channels_count):
-        sig = ["Channel {} sample {}".format(i, j).encode(encoding) for j in range(cycles)]
+        sig = [f"Channel {i} sample {j}".encode(encoding) for j in range(cycles)]
         sig = Signal(
             np.array(sig),
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
-            comment="String channel {}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
+            comment=f"String channel {i}",
             raw=True,
             encoding=encoding,
         )
@@ -140,9 +139,9 @@ def generate_test_file(tmpdir, version="4.10"):
         sig = Signal(
             ones * i,
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
-            comment="Byte array channel {}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
+            comment=f"Byte array channel {i}",
             raw=True,
         )
         sigs.append(sig)
@@ -153,24 +152,24 @@ def generate_test_file(tmpdir, version="4.10"):
     ones = np.ones(cycles, dtype=np.uint64)
     conversion = {
         "raw": np.arange(255, dtype=np.float64),
-        "phys": np.array(["Value {}".format(i).encode("ascii") for i in range(255)]),
+        "phys": np.array([f"Value {i}".encode("ascii") for i in range(255)]),
         "conversion_type": v4c.CONVERSION_TYPE_TABX if version >= "4.00" else v3c.CONVERSION_TYPE_TABX,
         "links_nr": 260,
         "ref_param_nr": 255,
     }
 
     for i in range(255):
-        conversion["val_{}".format(i)] = conversion["param_val_{}".format(i)] = conversion["raw"][i]
-        conversion["text_{}".format(i)] = conversion["phys"][i]
-    conversion["text_{}".format(255)] = "Default"
+        conversion[f"val_{i}"] = conversion[f"param_val_{i}"] = conversion["raw"][i]
+        conversion[f"text_{i}"] = conversion["phys"][i]
+    conversion[f"text_{255}"] = "Default"
 
     for i in range(channels_count):
         sig = Signal(
             ones * i,
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
-            comment="Value to text channel {}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
+            comment=f"Value to text channel {i}",
             conversion=cls(**conversion),
             raw=True,
         )
@@ -201,18 +200,18 @@ def generate_arrays_test_file(tmpdir):
         ]
 
         types = [
-            ("Channel_{}".format(i), "(2, 3)<u8"),
-            ("channel_{}_axis_1".format(i), "(2, )<u8"),
-            ("channel_{}_axis_2".format(i), "(3, )<u8"),
+            (f"Channel_{i}", "(2, 3)<u8"),
+            (f"channel_{i}_axis_1", "(2, )<u8"),
+            (f"channel_{i}_axis_2", "(3, )<u8"),
         ]
 
         sig = Signal(
             np.core.records.fromarrays(samples, dtype=np.dtype(types)),
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
             conversion=None,
-            comment="Array channel {}".format(i),
+            comment=f"Array channel {i}",
             raw=True,
         )
         sigs.append(sig)
@@ -223,15 +222,15 @@ def generate_arrays_test_file(tmpdir):
     for i in range(array_channels_count):
         samples = [np.ones((cycles, 2, 3), dtype=np.uint64) * i]
 
-        types = [("Channel_{}".format(i), "(2, 3)<u8")]
+        types = [(f"Channel_{i}", "(2, 3)<u8")]
 
         sig = Signal(
             np.core.records.fromarrays(samples, dtype=np.dtype(types)),
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
             conversion=None,
-            comment="Array channel {} with default axis".format(i),
+            comment=f"Array channel {i} with default axis",
             raw=True,
         )
         sigs.append(sig)
@@ -252,23 +251,23 @@ def generate_arrays_test_file(tmpdir):
         ]
 
         types = [
-            ("struct_{}_channel_0".format(i), np.uint8),
-            ("struct_{}_channel_1".format(i), np.uint16),
-            ("struct_{}_channel_2".format(i), np.uint32),
-            ("struct_{}_channel_3".format(i), np.uint64),
-            ("struct_{}_channel_4".format(i), np.int8),
-            ("struct_{}_channel_5".format(i), np.int16),
-            ("struct_{}_channel_6".format(i), np.int32),
-            ("struct_{}_channel_7".format(i), np.int64),
+            (f"struct_{i}_channel_0", np.uint8),
+            (f"struct_{i}_channel_1", np.uint16),
+            (f"struct_{i}_channel_2", np.uint32),
+            (f"struct_{i}_channel_3", np.uint64),
+            (f"struct_{i}_channel_4", np.int8),
+            (f"struct_{i}_channel_5", np.int16),
+            (f"struct_{i}_channel_6", np.int32),
+            (f"struct_{i}_channel_7", np.int64),
         ]
 
         sig = Signal(
             np.core.records.fromarrays(samples, dtype=np.dtype(types)),
             t,
-            name="Channel_{}".format(i),
-            unit="unit_{}".format(i),
+            name=f"Channel_{i}",
+            unit=f"unit_{i}",
             conversion=None,
-            comment="Structure channel composition {}".format(i),
+            comment=f"Structure channel composition {i}",
             raw=True,
         )
         sigs.append(sig)


### PR DESCRIPTION
This print statement seems unnecessary. It originates from 4e2b2d27af1ed1312fdb4276bf4a80a9fa8e546e but I cant't see the purpose. Could it just be removed?

For me it started to appear just now that I changed my Python environment. Everytime I run Signal.plot I get an error printed (no actual error, just the traceback printed) because the call to gui.plot 4 lines above the print raises an Exception since importing PySide6 fails in my environment. But Signal.plot produces a plot, so no need to show an error I guess.