### PR TITLE
Add return to iter_to_dataframe when filtering channels

### DIFF
--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -3929,7 +3929,10 @@ class MDF:
                 yield df
 
             mdf.close()
+            return
 
+        # else: channels is None
+            
         df = {}
         self._set_temporary_master(None)
 


### PR DESCRIPTION
Bugfix:

mdf iter_to_dataframe takes channels parameter to allow filtering.
In this case a filtering is set for the mdf and same member function is invoked.
However at the end of this `if` clause there is no return, effectively continuing into the "else" codepath instead of stopping the iteration. Effectively we get duplicated / more rows.

Added return.

fyi: @danielhrisca