### PR TITLE
process signal_data with data_type v4c.DATA_TYPE_SIGNED_INTEL and v4c.DATA_TYPE_SIGNED_MOTOROLA

### DIFF
--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -7509,6 +7509,8 @@ class MDF4(MDF_Common):
                     v4c.DATA_TYPE_BYTEARRAY,
                     v4c.DATA_TYPE_UNSIGNED_INTEL,
                     v4c.DATA_TYPE_UNSIGNED_MOTOROLA,
+                    v4c.DATA_TYPE_SIGNED_INTEL,
+                    v4c.DATA_TYPE_SIGNED_MOTOROLA,
                     v4c.DATA_TYPE_MIME_SAMPLE,
                     v4c.DATA_TYPE_MIME_STREAM,
                 ):
@@ -7533,6 +7535,8 @@ class MDF4(MDF_Common):
                     v4c.DATA_TYPE_BYTEARRAY,
                     v4c.DATA_TYPE_UNSIGNED_INTEL,
                     v4c.DATA_TYPE_UNSIGNED_MOTOROLA,
+                    v4c.DATA_TYPE_SIGNED_INTEL,
+                    v4c.DATA_TYPE_SIGNED_MOTOROLA,
                     v4c.DATA_TYPE_MIME_SAMPLE,
                     v4c.DATA_TYPE_MIME_STREAM,
                 ):


### PR DESCRIPTION
After upgrading to INCA V7.2 I get .mf4-files that contain data of type signed intel. Adding those lines fixes the problem and I can import the measurement.

The following was the error log

```---------------------------------------------------------------------------
MdfException                              Traceback (most recent call last)
[c:\%some_path%](file:///C:/%some_path%) %some_file%.ipynb Zelle 3 line 5
      [3](vscode-notebook-cell:/c%3A/%some_file%.ipynb#W2sZmlsZQ%3D%3D?line=2) dfs = []
      [4](vscode-notebook-cell:/c%3A/%some_file%.ipynb#W2sZmlsZQ%3D%3D?line=3) for file in files:
----> [5](vscode-notebook-cell:/c%3A/%some_file%.ipynb#W2sZmlsZQ%3D%3D?line=4)     df = MDF(file).to_dataframe(raster=0.01)
      [7](vscode-notebook-cell:/c%3A/%some_file%.ipynb#W2sZmlsZQ%3D%3D?line=6)     columns_dict = {}
      [8](vscode-notebook-cell:/c%3A/%some_file%.ipynb#W2sZmlsZQ%3D%3D?line=7)     # Handle Device Name

File [c:\%some_Anaconda3_env%\lib\site-packages\asammdf\mdf.py:4274](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:4274), in MDF.to_dataframe(self, channels, raster, time_from_zero, empty_channels, keep_arrays, use_display_names, time_as_date, reduce_memory_usage, raw, ignore_value2text_conversions, use_interpolation, only_basenames, interpolate_outwards_with_nan, numeric_1D_only)
   [4261](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:4261)     continue
   [4263](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:4263) channels = [
   [4264](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:4264)     (None, gp_index, ch_index)
   [4265](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:4265)     for gp_index, channel_indexes in self.included_channels(
   (...)
   [4269](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:4269)     if ch_index != self.masters_db.get(gp_index, None)
   [4270](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:4270) ]
   [4272](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:4272) signals = [
   [4273](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:4273)     signal
-> [4274](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:4274)     for signal in self.select(
   [4275](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:4275)         channels, raw=True, copy_master=False, validate=False
   [4276](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:4276)     )
   [4277](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:4277) ]
   [4279](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:4279) if not signals:
   [4280](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:4280)     continue

File [c:\%some_Anaconda3_env%\lib\site-packages\asammdf\mdf.py:3163](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:3163), in MDF.select(self, channels, record_offset, raw, copy_master, ignore_value2text_conversions, record_count, validate)
   [3159](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:3159) signals = []
   [3161](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:3161) current_pos = 0
-> [3163](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:3163) for idx, sigs in enumerate(
   [3164](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:3164)     self._yield_selected_signals(
   [3165](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:3165)         virtual_group,
   [3166](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:3166)         groups=groups,
   [3167](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:3167)         record_offset=record_offset,
   [3168](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:3168)         record_count=record_count,
   [3169](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:3169)     )
   [3170](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:3170) ):
   [3171](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:3171)     if not sigs:
   [3172](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/mdf.py:3172)         break

File [c:\%some_Anaconda3_env%\lib\site-packages\asammdf\blocks\mdf_v4.py:8070](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:8070), in MDF4._yield_selected_signals(self, index, groups, record_offset, record_count, skip_master, version)
   [8067](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:8067) if idx == 0:
   [8068](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:8068)     for channel_index in channels:
   [8069](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:8069)         signals.append(
-> [8070](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:8070)             self.get(
   [8071](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:8071)                 group=group_index,
   [8072](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:8072)                 index=channel_index,
   [8073](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:8073)                 data=fragment,
   [8074](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:8074)                 raw=True,
   [8075](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:8075)                 ignore_invalidation_bits=True,
   [8076](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:8076)                 samples_only=False,
   [8077](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:8077)             )
   [8078](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:8078)         )
   [8079](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:8079)     pass
   [8080](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:8080) else:

File [c:\%some_Anaconda3_env%\lib\site-packages\asammdf\blocks\mdf_v4.py:6595](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6595), in MDF4.get(self, name, group, index, raster, samples_only, data, raw, ignore_invalidation_bits, record_offset, record_count, skip_channel_validation)
   [6580](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6580)         vals, timestamps, invalidation_bits, encoding = self._get_array(
   [6581](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6581)             channel=channel,
   [6582](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6582)             group=grp,
   (...)
   [6591](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6591)             master_is_required=master_is_required,
   [6592](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6592)         )
   [6594](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6594) else:
-> [6595](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6595)     vals, timestamps, invalidation_bits, encoding = self._get_scalar(
   [6596](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6596)         channel=channel,
   [6597](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6597)         group=grp,
   [6598](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6598)         group_index=gp_nr,
   [6599](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6599)         channel_index=ch_nr,
   [6600](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6600)         dependency_list=dependency_list,
   [6601](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6601)         raster=raster,
   [6602](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6602)         data=data,
   [6603](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6603)         ignore_invalidation_bits=ignore_invalidation_bits,
   [6604](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6604)         record_offset=record_offset,
   [6605](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6605)         record_count=record_count,
   [6606](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6606)         master_is_required=master_is_required,
   [6607](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6607)     )
   [6609](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6609) if samples_only:
   [6610](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:6610)     if not raw:

File [c:\%some_Anaconda3_env%\lib\site-packages\asammdf\blocks\mdf_v4.py:7607](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:7607), in MDF4._get_scalar(self, channel, group, group_index, channel_index, dependency_list, raster, data, ignore_invalidation_bits, record_offset, record_count, master_is_required)
   [7604](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:7604)             encoding = "latin-1"
   [7606](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:7606)         else:
-> [7607](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:7607)             raise MdfException(
   [7608](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:7608)                 f'wrong data type "{data_type}", "{type(data_type)}" for vlsd channel "{channel.name}"'
   [7609](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:7609)             )
   [7610](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:7610) else:
   [7611](file:///C:/%some_Anaconda3_env%/lib/site-packages/asammdf/blocks/mdf_v4.py:7611)     if len(vals):

MdfException: wrong data type "2", "<class 'int'>" for vlsd channel "data"```