### PR TITLE
Provide acq_name and acq_source to append method when filtering

### DIFF
--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -2068,6 +2068,8 @@ class MDF:
                             sigs,
                             common_timebase=True,
                             comment=cg.comment,
+                            acq_name=cg.acq_name,
+                            acq_source=cg.acq_source,
                         )
                         MDF._transfer_channel_group_data(mdf.groups[cg_nr].channel_group, cg)
                     else:

--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -2068,8 +2068,8 @@ class MDF:
                             sigs,
                             common_timebase=True,
                             comment=cg.comment,
-                            acq_name=cg.acq_name,
-                            acq_source=cg.acq_source,
+                            acq_name=getattr(cg, "acq_name", None),
+                            acq_source=getattr(cg, "acq_source", None),
                         )
                         MDF._transfer_channel_group_data(mdf.groups[cg_nr].channel_group, cg)
                     else:


### PR DESCRIPTION
The channel group acquisition properties of a filtered MDF aren't copied across for MDF versions 4.20 and greater. See the example below for a minimal reproducible example:

```py
from asammdf import MDF, Signal

t, v = [0, 1], [2, 4]
acq_name = "ExampleTask"
signal_name = f"Task.Struct.Value"

for version in ("4.10", "4.20"):
    mdf1 = MDF(version=version)
    mdf1.append([Signal(v, t, name=signal_name)], acq_name=acq_name)

    mdf2 = mdf1.filter([signal_name])
    cg_nr, _ = mdf2.channels_db[signal_name][0]
    
    result_acq_name = mdf2.groups[cg_nr].channel_group.acq_name
    print(f"Version {version}: {result_acq_name}")
```

I would expect this to print
```
Version 4.10: ExampleTask
Version 4.20: ExampleTask
```

However instead we see
```
Version 4.10: ExampleTask
Version 4.20: None
```

This appears to be due to the call to [_append_column_oriented for 4.20 version MDFs](https://github.com/danielhrisca/asammdf/blob/master/src/asammdf/blocks/mdf_v4.py#L2711), which creates multiple groups. However the `filter` method [only updates the acquisition properties for the first group](https://github.com/danielhrisca/asammdf/blob/master/src/asammdf/mdf.py#L2072).

A simple fix is to pass the `acq_source` and `acq_name` to the `append` method. However I am unsure if this is the proper solution. Perhaps the current behavior is intended? Or perhaps this change has further ramifications?
