### PR TITLE
Fix reading of CA-CN structures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,10 @@ When submitting PR's please take into account:
 
 # Testing
 
-You can use tox to run tests locally. Example for the unit tests with Python version 3.7:
+You can use tox to run tests locally. Example for the unit tests with Python version 3.9:
 
 ```console
-tox -e py27
+tox -e py39
 ```
 
 Otherwise, you can just push and the tests will be run by GitHub Actions.

--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -1044,6 +1044,13 @@ class MDF4(MDF_Common):
                     first_dep = ca_block = ChannelArrayBlock(address=component_addr, stream=stream, mapped=mapped)
                     dependencies[index] = [first_dep]
 
+                    ca_cnt = len(dependencies[index])
+                    byte_offset_factors = []
+                    bit_pos_inval_factors = []
+                    dimensions = []
+                    total_elem = 1
+
+                    # recurse into CA structure
                     while ca_block.composition_addr:
                         stream.seek(ca_block.composition_addr)
                         blk_id = stream.read(4)
@@ -1071,104 +1078,8 @@ class MDF4(MDF_Common):
                                 mapped=mapped,
                             )
 
-                            ca_cnt = len(dependencies[index])
                             if ret_composition:
                                 dependencies[index].extend(ret_composition)
-
-                            byte_offset_factors = []
-                            bit_pos_inval_factors = []
-                            dimensions = []
-                            total_elem = 1
-
-                            for ca_blck in dependencies[index][:ca_cnt]:
-                                # only consider CN templates
-                                if ca_blck.ca_type != v4c.CA_STORAGE_TYPE_CN_TEMPLATE:
-                                    logger.warning("Only CN template arrays are supported")
-                                    continue
-
-                                # 1D array with dimensions
-                                for i in range(ca_blck.dims):
-                                    dim_size = ca_blck[f"dim_size_{i}"]
-                                    dimensions.append(dim_size)
-                                    total_elem *= dim_size
-
-                                # 1D arrays for byte offset and invalidation bit pos calculations
-                                byte_offset_factors.extend(ca_blck.get_byte_offset_factors())
-                                bit_pos_inval_factors.extend(ca_blck.get_bit_pos_inval_factors())
-
-                            multipliers = [1] * len(dimensions)
-                            for i in range(len(dimensions) - 2, -1, -1):
-                                multipliers[i] = multipliers[i + 1] * dimensions[i + 1]
-
-                            def _get_nd_coords(index, factors: list[int]) -> list[int]:
-                                """Convert 1D index to CA's nD coordinates"""
-                                coords = [0] * len(factors)
-                                for i, factor in enumerate(factors):
-                                    coords[i] = index // factor
-                                    index %= factor
-                                return coords
-
-                            def _get_name_with_indices(ch_name: str, ch_parent_name: str, indices: list[int]) -> str:
-                                coords = "[" + "][".join(str(coord) for coord in indices) + "]"
-                                m = re.match(ch_parent_name, ch_name)
-                                n = re.search(r"\[\d+\]", ch_name)
-                                if m:
-                                    name = ch_name[: m.end()] + coords + ch_name[m.end() :]
-                                elif n:
-                                    name = ch_name[: n.start()] + coords + ch_name[n.start() :]
-                                else:
-                                    name = ch_name + coords
-                                return name
-
-                            ch_len = len(channels)
-                            for elem_id in range(1, total_elem):
-                                for cn_id in range(index, ch_len):
-                                    nd_coords = _get_nd_coords(elem_id, multipliers)
-
-                                    # copy composition block
-                                    new_block = deepcopy(channels[cn_id])
-
-                                    # update byte offset & position of invalidation bit
-                                    byte_offset = bit_offset = 0
-                                    for coord, byte_factor, bit_factor in zip(
-                                        nd_coords, byte_offset_factors, bit_pos_inval_factors
-                                    ):
-                                        byte_offset += coord * byte_factor
-                                        bit_offset += coord * bit_factor
-                                    new_block.byte_offset += byte_offset
-                                    new_block.pos_invalidation_bit += bit_offset
-
-                                    # update channel name
-                                    new_block.name = _get_name_with_indices(new_block.name, channel.name, nd_coords)
-
-                                    # append to channel list
-                                    channels.append(new_block)
-
-                                    # update channel dependencies
-                                    if dependencies[cn_id] is not None:
-                                        deps = []
-                                        for dep in dependencies[cn_id]:
-                                            if not isinstance(dep, ChannelArrayBlock):
-                                                dep_entry = (dep[0], dep[1] + (ch_len - index) * elem_id)
-                                                deps.append(dep_entry)
-                                        dependencies.append(deps)
-                                    else:
-                                        dependencies.append(None)
-
-                                    # update channels db
-                                    entry = (dg_cntr, ch_cntr)
-                                    self.channels_db.add(new_block.name, entry)
-                                    ch_cntr += 1
-
-                            # modify channels' names found recursively in-place
-                            orig_name = channel.name
-                            for cn_id in range(index, ch_len):
-                                nd_coords = _get_nd_coords(0, multipliers)
-                                name = _get_name_with_indices(channels[cn_id].name, orig_name, nd_coords)
-                                entry = self.channels_db.pop(channels[cn_id].name)
-                                channels[cn_id].name = name
-                                # original channel entry will only contain single source tuple
-                                self.channels_db.add(name, entry[0])
 
                             break
 
@@ -1177,6 +1088,90 @@ class MDF4(MDF_Common):
                                 "skipping CN block; Nested CA structure should be contained within BYTEARRAY data type"
                             )
                             break
+
+                    # create channels from ca block
+                    for ca_blck in dependencies[index][:ca_cnt]:
+                        # only consider CN templates
+                        if ca_blck.ca_type != v4c.CA_STORAGE_TYPE_CN_TEMPLATE:
+                            logger.warning("Only CN template arrays are supported")
+                            continue
+
+                        # 1D array with dimensions
+                        for i in range(ca_blck.dims):
+                            dim_size = ca_blck[f"dim_size_{i}"]
+                            dimensions.append(dim_size)
+                            total_elem *= dim_size
+
+                        # 1D arrays for byte offset and invalidation bit pos calculations
+                        byte_offset_factors.extend(ca_blck.get_byte_offset_factors())
+                        bit_pos_inval_factors.extend(ca_blck.get_bit_pos_inval_factors())
+
+                    multipliers = [1] * len(dimensions)
+                    for i in range(len(dimensions) - 2, -1, -1):
+                        multipliers[i] = multipliers[i + 1] * dimensions[i + 1]
+
+                    def _get_nd_coords(index, factors: list[int]) -> list[int]:
+                        """Convert 1D index to CA's nD coordinates"""
+                        coords = [0] * len(factors)
+                        for i, factor in enumerate(factors):
+                            coords[i] = index // factor
+                            index %= factor
+                        return coords
+
+                    def _get_name_with_indices(ch_name: str, ch_parent_name: str, indices: list[int]) -> str:
+                        coords = "[" + "][".join(str(coord) for coord in indices) + "]"
+                        m = re.match(ch_parent_name, ch_name)
+                        n = re.search(r"\[\d+\]", ch_name)
+                        if m:
+                            name = ch_name[: m.end()] + coords + ch_name[m.end() :]
+                        elif n:
+                            name = ch_name[: n.start()] + coords + ch_name[n.start() :]
+                        else:
+                            name = ch_name + coords
+                        return name
+
+                    ch_len = len(channels)
+                    for elem_id in range(total_elem):
+                        for cn_id in range(index, ch_len):
+                            nd_coords = _get_nd_coords(elem_id, multipliers)
+
+                            # copy composition block
+                            new_block = deepcopy(channels[cn_id])
+
+                            # update byte offset & position of invalidation bit
+                            byte_offset = bit_offset = 0
+                            for coord, byte_factor, bit_factor in zip(
+                                nd_coords, byte_offset_factors, bit_pos_inval_factors
+                            ):
+                                byte_offset += coord * byte_factor
+                                bit_offset += coord * bit_factor
+                            new_block.byte_offset += byte_offset
+                            new_block.pos_invalidation_bit += bit_offset
+
+                            # update channel name
+                            new_block.name = _get_name_with_indices(new_block.name, channel.name, nd_coords)
+
+                            # append to channel list
+                            channels.append(new_block)
+
+                            # update channel dependencies
+                            if dependencies[cn_id] is not None:
+                                deps = []
+                                for dep in dependencies[cn_id]:
+                                    if not isinstance(dep, ChannelArrayBlock):
+                                        dep_entry = (dep[0], dep[1] + (ch_len - index) * elem_id)
+                                        deps.append(dep_entry)
+                                if deps:
+                                    dependencies.append(deps)
+                                else:
+                                    dependencies.append(None)
+                            else:
+                                dependencies.append(None)
+
+                            # update channels db
+                            entry = (dg_cntr, ch_cntr)
+                            self.channels_db.add(new_block.name, entry)
+                            ch_cntr += 1
 
             else:
                 dependencies.append(None)

--- a/tox.ini
+++ b/tox.ini
@@ -14,12 +14,12 @@ deps =
     pytest-timeout
     pyautogui; sys_platform != "win32"
     pywin32; sys_platform == "win32"
-passenv = DISPLAY,XAUTHORITY
+passenv = DISPLAY,XAUTHORITY,HTTP_PROXY,HTTPS_PROXY
 setenv =
     DISPLAY = :0
     QT_DEBUG_PLUGINS = 1
 commands =
-    coverage run --rcfile=pyproject.toml --module pytest
+    coverage run --rcfile=pyproject.toml --module pytest {posargs}
     coverage report --rcfile=pyproject.toml
 
 [testenv:style]


### PR DESCRIPTION
Inside a CA-CN structure, if last element is a CA block no new channels will be created out of CA.
Also, modified `_read_channel` to not replace original channel name in-place, instead a new channel is created.

P.S. Updated python version in CONTRIBUTING.md