### PR TITLE
Add import for retrieving zips

### DIFF
--- a/test/test_CAN_bus_loogging.py
+++ b/test/test_CAN_bus_loogging.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import tempfile
 import unittest
 import urllib
+import urllib.request
 from zipfile import ZipFile
 
 import numpy as np


### PR DESCRIPTION
Retrieving zips with urlllib requires explicit import of its request module