### PR TITLE
fix(mdf_v2_v3): getuser raises OSError when pwd module is not found i…

### DIFF
--- a/src/asammdf/blocks/v2_v3_blocks.py
+++ b/src/asammdf/blocks/v2_v3_blocks.py
@@ -2729,7 +2729,7 @@ class HeaderBlock:
             self.dg_nr = 0
             try:
                 user = getuser()
-            except ModuleNotFoundError:
+            except (ModuleNotFoundError, OSError):
                 user = ""
             self.author_field = f"{user:\0<32}".encode("latin-1")
             self.department_field = "{:\0<32}".format("").encode("latin-1")


### PR DESCRIPTION
…n Python 3.13

The CI looks good now but there is still some tests for the GUI that are flaky and need to be fixed: [`TestDoubleClick.test_EnableDisable_Subgroup`](https://github.com/danielhrisca/asammdf/actions/runs/11933613029/job/33261021648#step:6:303), [`TestContextMenu.test_Action_CopyChannelStructure_Channel`](https://github.com/danielhrisca/asammdf/actions/runs/11941413148/job/33286190799?pr=1101#step:6:132), and [`TestDoubleClick.test_EnableDisable_ParentGroup`](https://github.com/danielhrisca/asammdf/actions/runs/11941413148/job/33286190148?pr=1101#step:6:352)

Edit: with PR #1103 it fixes the CI completely