### PR TITLE
feat(gui): do not always require decode and export extras dependencie…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,6 @@ setup(
         ],
         "export_matlab_v5": "scipy",
         "gui": [
-            "asammdf[decode,export]",
             "natsort",
             "PySide6",
             "pyqtgraph",


### PR DESCRIPTION
…s for gui extra

Hi @danielhrisca, in PR #1097 [I made decode and export extras required for the gui extra](https://github.com/danielhrisca/asammdf/pull/1097/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R119) because I saw it specified for the entry points [here (line 138)](https://github.com/danielhrisca/asammdf/pull/1097/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L138). However looking at the code it seems it is not required so I am removing this again. If you still prefer to keep them required you can just close this PR