### PR TITLE
fix tz_offset being unsigned int

### DIFF
--- a/src/asammdf/blocks/v2_v3_constants.py
+++ b/src/asammdf/blocks/v2_v3_constants.py
@@ -230,7 +230,7 @@ COMMON_u = struct.Struct(FMT_COMMON).unpack
 COMMON_uf = struct.Struct(FMT_COMMON).unpack_from
 COMMON_p = struct.Struct(FMT_COMMON).pack
 
-HEADER_POST_320_EXTRA_FMT = "Q2H32s"
+HEADER_POST_320_EXTRA_FMT = "QhH32s"
 HEADER_POST_320_EXTRA_KEYS = (
     "abs_time",
     "tz_offset",


### PR DESCRIPTION
fix tz_offset being unsigned int, however it's supposed to be a signed int

In the MDF spec for v3:
INT16 1 UTC time offset in hours (= GMT time zone)

The time offset is defined as INT16, not UINT16.

If the time offset is negative, but interpreted as UINT16, it will result in a very large positive number.