### PR TITLE
Add button to create a report of installed dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@ MANIFEST
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/asammdf.spec
+++ b/asammdf.spec
@@ -3,12 +3,20 @@ import os
 from pathlib import Path
 import sys
 
+from PyInstaller.utils.hooks import copy_metadata
+
+from asammdf.gui.dialogs.dependencies_dlg import find_all_dependencies
+
 sys.setrecursionlimit(sys.getrecursionlimit() * 5)
 
 asammdf_path = Path.cwd() / "src" / "asammdf" / "app" / "asammdfgui.py"
 
 block_cipher = None
 added_files = []
+
+# get metadata for importlib.metadata (used by DependenciesDlg)
+for dep in find_all_dependencies("asammdf"):
+    added_files += copy_metadata(dep)
 
 for root, dirs, files in os.walk(asammdf_path.parent / "ui"):
     for file in files:

--- a/src/asammdf/gui/dialogs/dependencies_dlg.py
+++ b/src/asammdf/gui/dialogs/dependencies_dlg.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import contextlib
 from importlib.metadata import distribution, PackageNotFoundError
 import re
@@ -5,21 +6,29 @@ from typing import Optional
 
 from packaging.requirements import Requirement
 from PySide6.QtCore import QSize
-from PySide6.QtGui import QIcon
-from PySide6.QtWidgets import QDialog, QTreeWidget, QTreeWidgetItem, QVBoxLayout
+from PySide6.QtGui import QGuiApplication, QIcon
+from PySide6.QtWidgets import (
+    QDialog,
+    QPushButton,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+)
 
 
 class DependenciesDlg(QDialog):
-    def __init__(self, package_name: str) -> None:
+    def __init__(self, package_name: str, is_root_package: bool = True) -> None:
         """Create a dialog to list all dependencies for `package_name`."""
 
         super().__init__()
 
         # Variables
         self._package_name = package_name
+        self._is_root_package = is_root_package
 
         # Widgets
         self._tree = QTreeWidget()
+        self._copy_btn = QPushButton("Copy installed dependencies to clipboard")
 
         # Setup widgets
         self._setup_widgets()
@@ -48,14 +57,19 @@ class DependenciesDlg(QDialog):
         self._tree.resizeColumnToContents(1)
         self._tree.resizeColumnToContents(2)
 
+        # enable copy button for root package only
+        self._copy_btn.setVisible(self._is_root_package)
+
     def _setup_layout(self) -> None:
         vbox = QVBoxLayout()
         self.setLayout(vbox)
 
         vbox.addWidget(self._tree)
+        vbox.addWidget(self._copy_btn)
 
     def _connect_signals(self) -> None:
         self._tree.itemDoubleClicked.connect(self._on_item_double_clicked)
+        self._copy_btn.clicked.connect(self._on_copy_button_clicked)
 
     def _populate_tree(self, package_name: str) -> None:
         package_dist = distribution(package_name)
@@ -82,27 +96,22 @@ class DependenciesDlg(QDialog):
             self._tree.invisibleRootItem().addChild(new_root_node)
             return new_root_node
 
-        for req_string in requires:
-            req = Requirement(req_string)
+        for group, requirements in grouped_dependencies(package_name).items():
+            for req_string in requirements:
+                req = Requirement(req_string)
+                parent_node = get_root_node(group)
 
-            parent = get_root_node()
+                item = QTreeWidgetItem()
+                item.setText(0, req.name)
+                item.setText(1, str(req.specifier))
 
-            if req.marker is not None:
-                match = re.search(r"extra\s*==\s*['\"](?P<extra>\S+)['\"]", str(req.marker))
-                if match:
-                    parent = get_root_node(match["extra"])
+                with contextlib.suppress(PackageNotFoundError):
+                    dist = distribution(req.name)
+                    item.setText(2, str(dist.version))
+                    item.setText(3, dist.metadata["Summary"])
+                    item.setText(4, dist.metadata["Home-Page"])
 
-            item = QTreeWidgetItem()
-            item.setText(0, req.name)
-            item.setText(1, str(req.specifier))
-
-            with contextlib.suppress(PackageNotFoundError):
-                dist = distribution(req.name)
-                item.setText(2, str(dist.version))
-                item.setText(3, dist.metadata["Summary"])
-                item.setText(4, dist.metadata["Home-Page"])
-
-            parent.addChild(item)
+                parent_node.addChild(item)
 
     def _on_item_double_clicked(self, item: QTreeWidgetItem, column: int) -> None:
         if column != 0:
@@ -111,9 +120,84 @@ class DependenciesDlg(QDialog):
             return
 
         package_name = item.text(0)
-        DependenciesDlg.show_dependencies(package_name)
+        DependenciesDlg.show_dependencies(package_name, is_root_package=False)
+
+    def _on_copy_button_clicked(self) -> None:
+        """Create a list of all dependencies and their versions and write it to clipboard."""
+        lines: list[str] = []
+        dependencies = find_all_dependencies(self._package_name)
+        max_name_length = max(len(name) for name in dependencies)
+
+        header = f"{'Package':<{max_name_length}} Version"
+        lines.append(header)
+        lines.append("-" * len(header))
+        for name in sorted(dependencies):
+            version = distribution(name).version
+            lines.append(f"{name:<{max_name_length}} {version}")
+
+        # write to clipboard
+        QGuiApplication.clipboard().setText("\n".join(lines))
 
     @staticmethod
-    def show_dependencies(package_name: str) -> None:
-        dlg = DependenciesDlg(package_name)
-        dlg.exec_()
+    def show_dependencies(package_name: str, is_root_package: bool = True) -> None:
+        dlg = DependenciesDlg(package_name, is_root_package)
+        dlg.exec()
+
+
+def grouped_dependencies(package_name: str) -> dict[str, list[str]]:
+    """Retrieve a dictionary grouping the dependencies of a given package into mandatory and optional categories.
+
+    This function fetches the dependencies of the specified package and categorizes them into groups, such as
+    'mandatory' or any optional feature groups specified by `extra` markers.
+
+    :param package_name:
+        The name of the package to analyze.
+    :return:
+        A dictionary where keys are group names (e.g., 'mandatory', 'extra_feature')
+        and values are lists of package names corresponding to those groups.
+    """
+    dependencies: defaultdict[str, list[str]] = defaultdict(list)
+    package_dist = distribution(package_name)
+
+    if requires := package_dist.requires:
+        for req_string in requires:
+            req = Requirement(req_string)
+
+            group = "mandatory"
+            if match := re.search(r"extra\s*==\s*['\"](?P<extra>\S+)['\"]", str(req.marker)):
+                group = match["extra"]
+
+            dependencies[group].append(req_string)
+    return dependencies
+
+
+def find_all_dependencies(package_name: str) -> set[str]:
+    """Recursively find all dependencies of a given package, including transitive dependencies.
+
+    This function determines all dependencies of the specified package, following any transitive dependencies
+    (i.e., dependencies of dependencies) and returning a complete set of package names.
+
+    :param package_name:
+        The name of the package to analyze.
+    :return:
+        A set of all dependencies for the package, including transitive dependencies.
+    """
+
+    def _flatten_groups(grouped_deps: dict[str, list[str]]) -> set[str]:
+        _dep_set = set()
+        for group, requirements in grouped_deps.items():
+            _dep_set |= {Requirement(req_string).name for req_string in requirements}
+        return _dep_set
+
+    dep_set: set[str] = {package_name}
+    todo = _flatten_groups(grouped_dependencies(package_name))
+    while todo:
+        req_name = todo.pop()
+        if req_name in dep_set:
+            continue
+        try:
+            todo |= _flatten_groups(grouped_dependencies(req_name))
+        except PackageNotFoundError:
+            continue
+        dep_set.add(req_name)
+    return dep_set


### PR DESCRIPTION
I had to change a few things, so pyinstaller builds can access the package metadata.
Here is the new button below the table:
![image](https://github.com/user-attachments/assets/7bb2c021-890d-4e6e-9585-c84319d91a99)


The output might be useful for creating bug reports:

<details>

<summary>Example Output</summary>


```
Package            Version
--------------------------
PySide6            6.8.1
PySide6-Addons     6.8.1
PySide6-Essentials 6.8.1
QtPy               2.4.2
asammdf            8.1.0.dev3
attrs              24.2.0
backports.tarfile  1.2.0
canmatrix          1.0
cffi               1.17.1
chardet            5.2.0
click              8.1.7
colorama           0.4.6
cramjam            2.9.0
cryptography       44.0.0
faust-cchardet     2.1.19
future             1.0.0
h5py               3.12.1
hdf5storage        0.1.19
importlib-metadata 8.0.0
isal               1.7.1
jaraco.classes     3.4.0
jaraco.context     6.0.1
jaraco.functools   4.1.0
keyring            25.5.0
lxml               5.3.0
lz4                4.3.3
more-itertools     10.5.0
natsort            8.4.0
numexpr            2.10.2
numpy              2.2.0
packaging          24.2
pandas             2.2.3
pyarrow            18.1.0
pycparser          2.22
pyqtgraph          0.13.7
pyqtlet2           0.9.3
python-dateutil    2.9.0.post0
python-snappy      0.7.3
pytz               2024.2
pywin32-ctypes     0.2.3
qtpy               2.4.2
shiboken6          6.8.1
six                1.17.0
typing-extensions  4.12.2
tzdata             2024.2
zipp               3.19.2
```

</details>