### PR TITLE
Fix readthedocs "Config file validation error"

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: doc/conf.py


### PR DESCRIPTION
The last successful documentation build is for version 7.3.*

Lately the build fails with
![image](https://github.com/user-attachments/assets/cda22085-b780-4e57-8711-e5c687b30747)

