### PR TITLE
Hotfix/checkout fails in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-           submodules: 'recursive'
-           token: ${{ secrets.SUBMODULE_PAT }}
+          submodules: "recursive"
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -13,8 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-           submodules: 'recursive'
-           token: ${{ secrets.SUBMODULE_PAT }}
+          submodules: "recursive"
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-           submodules: 'recursive'
-           token: ${{ secrets.SUBMODULE_PAT }}
+          submodules: "recursive"
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,8 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-           submodules: 'recursive'
-           token: ${{ secrets.SUBMODULE_PAT }}
+          submodules: "recursive"
 
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Git checkout is failing in CI for branches in fork repositories but also for PR somehow because the token `SUBMODULE_PAT` only exists for the asammdf repository. I removed the token because it should not be needed as libdeflate is a public repository (tested in my repository and it worked) or is there any reason why it might be needed that I overlooked?