### PR TITLE
fix: tox does not install extras if they have underscores in their name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,10 @@ dependencies = [
 decode = ["faust-cchardet==2.1.19", "chardet"]
 export = ["pyarrow", "h5py", "hdf5storage>=0.1.19", "python-snappy", "polars"]
 testing = ["h5py", "pyarrow", "python-can", "scipy"]
-export_matlab_v5 = ["scipy"]
+export-matlab-v5 = ["scipy"]
 gui = ["natsort", "PySide6", "pyqtgraph", "pyqtlet2[PySide6]", "packaging"]
 encryption = ["cryptography", "keyring"]
-symbolic_math = ["sympy"]
+symbolic-math = ["sympy"]
 filesystem = ["fsspec"]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Development dependencies
---editable .[decode,encryption,export,export_matlab_v5,filesystem,gui,symbolic_math]
+--editable .[decode,encryption,export,export-matlab-v5,filesystem,gui,symbolic-math]
 --requirement benchmarks/requirements.txt
 --requirement ci/requirements.txt
 --requirement doc/requirements.txt

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,4 +2,5 @@ PyAutoGUI
 pytest
 pytest-cov
 pytest-timeout
+python-can
 xmlrunner; python_version < "3.12"

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,9 @@ envlist = py39, py310, py311, py312, py313, black, mypy, ruff, doc
 deps =
     --requirement test/requirements.txt
 extras =
+    export
+    export-matlab-v5
     gui
-    testing
 passenv = DISPLAY,XAUTHORITY
 setenv =
     DISPLAY = :0
@@ -35,10 +36,10 @@ extras =
     decode
     encryption
     export
-    export_matlab_v5
+    export-matlab-v5
     filesystem
     gui
-    symbolic_math
+    symbolic-math
 commands =
     mypy
 
@@ -64,9 +65,9 @@ extras =
     decode
     encryption
     export
-    export_matlab_v5
+    export-matlab-v5
     gui
-    symbolic_math
+    symbolic-math
 commands =
     pyinstaller asammdf.spec {posargs}
 


### PR DESCRIPTION
Switching to using hyphens instead of underscores fixes the issue. Underscores are replaced with hyphens anyway when packaging asammdf because the standard from pypa does not accept underscore: https://packaging.python.org/en/latest/specifications/core-metadata/#core-metadata-provides-extra

For pip install, it will still continue to work for users using underscores because pip replaces the underscores with hyphens automatically.

Ready for merge