### PR TITLE
Ci/update python for cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,7 +19,7 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel


### PR DESCRIPTION
We must update because cibuildwheel warns that starting with v3 it will only support python 3.11 and higher.

Ready for merge