### PR TITLE
Corrected misleading typo in ChannelConversion block's comment

### DIFF
--- a/src/asammdf/blocks/v4_blocks.py
+++ b/src/asammdf/blocks/v4_blocks.py
@@ -2224,7 +2224,7 @@ class ChannelConversion(_ChannelConversionBase):
 
     CCBLOCK common fields
 
-    * ``id`` - bytes : block ID; always b'##CG'
+    * ``id`` - bytes : block ID; always b'##CC'
     * ``reserved0`` - int : reserved bytes
     * ``block_len`` - int : block bytes size
     * ``links_nr`` - int : number of links


### PR DESCRIPTION
The code for the ChannelConversion block works well but one of its comments has a small typo contradicting the standard.
The docs are autogenerated from the code so they also show this typo.