### PR TITLE
Docstring style, examples, corrections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Clone the repository with submodules, make sure you have a C compiler installed,
 ```bash
 python -m venv .venv  # create virtual environment in .venv
 source .venv/bin/activate  # activate virtual environment (POSIX)
-.venv/Scripts/activate.bat  # activate virtual environment (Windows)
+.venv\Scripts\activate.bat  # activate virtual environment (Windows)
 pip install --requirement requirements.txt  # install development dependencies (includes asammdf in editable mode)
 ```
 

--- a/src/asammdf/blocks/mdf_common.py
+++ b/src/asammdf/blocks/mdf_common.py
@@ -17,7 +17,7 @@ __all__ = ["MDF_Common"]
 
 
 class MDF_Common:
-    """common methods for MDF objects"""
+    """Common methods for MDF objects."""
 
     def _set_temporary_master(self, master: NDArray[Any] | None) -> None:
         self._master = master
@@ -30,19 +30,20 @@ class MDF_Common:
         index: int | None = None,
     ) -> tuple[int, int]:
         """Gets channel comment.
+
         Channel can be specified in two ways:
 
         * using the first positional argument *name*
 
             * if there are multiple occurrences for this channel then the
-            *group* and *index* arguments can be used to select a specific
-            group.
+              *group* and *index* arguments can be used to select a specific
+              group.
             * if there are multiple occurrences for this channel and either the
-            *group* or *index* arguments is None then a warning is issued
+              *group* or *index* arguments is None then a warning is issued
 
         * using the group number (keyword argument *group*) and the channel
-        number (keyword argument *index*). Use *info* method for group and
-        channel numbers
+          number (keyword argument *index*). Use *info* method for group and
+          channel numbers
 
 
         Parameters

--- a/src/asammdf/blocks/mdf_v3.py
+++ b/src/asammdf/blocks/mdf_v3.py
@@ -116,15 +116,14 @@ class MDF3(MDF_Common):
     * ``channel_dependencies`` - list of *ChannelArrayBlock* in case of channel
       arrays; list of Channel objects in case of structure channel
       composition
-    * ``data_block`` - address of
-      data block
+    * ``data_block`` - address of data block
     * ``data_location``- integer code for data location (original file,
       temporary file or memory)
     * ``data_block_addr`` - list of raw samples starting addresses
     * ``data_block_type`` - list of codes for data block type
     * ``data_block_size`` - list of raw samples block size
     * ``sorted`` - sorted indicator flag
-    * ``record_size`` - dict that maps record ID's to record sizes in bytes
+    * ``record_size`` - dict that maps record IDs to record sizes in bytes
     * ``size`` - total size of data block for the current group
     * ``trigger`` - *Trigger* object for current group
 
@@ -163,7 +162,7 @@ class MDF3(MDF_Common):
 
     masters_db : dict
         used for fast master channel access; for each group index key the value
-         is the master channel index
+        is the master channel index
     memory : str
         memory optimization option
     name : string
@@ -974,7 +973,7 @@ class MDF3(MDF_Common):
         post_time: float = 0,
         comment: str = "",
     ) -> None:
-        """add trigger to data group
+        """Add trigger to data group.
 
         Parameters
         ----------
@@ -2086,9 +2085,7 @@ class MDF3(MDF_Common):
         comment: str = "",
         units: dict[str, str | bytes] | None = None,
     ) -> None:
-        """
-        Appends a new data group from a Pandas data frame.
-        """
+        """Appends a new data group from a Pandas DataFrame."""
         units = units or {}
 
         t = df.index
@@ -2335,9 +2332,9 @@ class MDF3(MDF_Common):
         gp.trigger = None
 
     def close(self) -> None:
-        """if the MDF was created with memory='minimum' and new
+        """If the MDF was created with memory='minimum' and new
         channels have been appended, then this must be called just before the
-        object is not used anymore to clean-up the temporary file
+        object is not used anymore to clean-up the temporary file.
 
         """
         try:
@@ -2386,8 +2383,7 @@ class MDF3(MDF_Common):
             print(format_exc())
 
     def extend(self, index: int, signals: list[tuple[NDArray[Any], None]]) -> None:
-        """
-        Extend a group with new samples. *signals* contains (values, invalidation_bits)
+        """Extend a group with new samples. *signals* contains (values, invalidation_bits)
         pairs for each extended signal. Since MDF3 does not support invalidation
         bits, the second item of each pair must be None. The first pair is the master channel's pair, and the
         next pairs must respect the same order in which the signals were appended. The samples must have raw
@@ -2671,6 +2667,7 @@ class MDF3(MDF_Common):
         index: int | None = None,
     ) -> str:
         """Gets channel comment.
+
         Channel can be specified in two ways:
 
         * using the first positional argument *name*
@@ -2763,6 +2760,7 @@ class MDF3(MDF_Common):
         skip_channel_validation: bool = False,
     ) -> Signal | tuple[NDArray[Any], None]:
         """Gets channel samples.
+
         Channel can be specified in two ways:
 
         * using the first positional argument *name*
@@ -2805,7 +2803,7 @@ class MDF3(MDF_Common):
             if *data=None* use this to select the record offset from which the
             group data should be loaded
         skip_channel_validation (False) : bool
-            skip validation of channel name, group index and channel index; defualt
+            skip validation of channel name, group index and channel index; default
             *False*. If *True*, the caller has to make sure that the *group* and *index*
             arguments are provided and are correct.
 
@@ -3158,16 +3156,16 @@ class MDF3(MDF_Common):
         record_count: int | None = None,
         one_piece: bool = False,
     ) -> NDArray[Any]:
-        """returns master channel samples for given group
+        """Returns master channel samples for given group.
 
         Parameters
         ----------
         index : int
             group index
         data : (bytes, int)
-            (data block raw bytes, fragment offset); default None
+            (data block raw bytes, fragment offset); default *None*
         raster : float
-            raster to be used for interpolation; default None
+            raster to be used for interpolation; default *None*
 
             .. deprecated:: 5.13.0
 
@@ -3313,10 +3311,10 @@ class MDF3(MDF_Common):
         return timestamps
 
     def iter_get_triggers(self) -> Iterator[TriggerInfoDict]:
-        """generator that yields triggers
+        """Generator that yields triggers.
 
-        Returns
-        -------
+        Yields
+        ------
         trigger_info : dict
             trigger information with the following keys:
 
@@ -3342,7 +3340,7 @@ class MDF3(MDF_Common):
                     yield trigger_info
 
     def info(self) -> dict[str, Any]:
-        """get MDF information as a dict
+        """Get MDF information as a dict.
 
         Examples
         --------
@@ -3378,7 +3376,7 @@ class MDF3(MDF_Common):
 
     @property
     def start_time(self) -> datetime:
-        """getter and setter the measurement start timestamp
+        """Getter and setter of the measurement start timestamp.
 
         Returns
         -------

--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -8854,9 +8854,8 @@ class MDF4(MDF_Common):
         raw: bool = False,
         ignore_value2text_conversion: bool = True,
     ) -> Signal:
-        """get CAN message signal. You can specify an external CAN database (
-        *database* argument) or canmatrix database object that has already been
-        loaded from a file (*db* argument).
+        """Get CAN message signal. You can specify an external CAN database path
+        or a canmatrix database object that has already been loaded from a file.
 
         The signal name can be specified in the following ways
 
@@ -9127,9 +9126,8 @@ class MDF4(MDF_Common):
         raw: bool = False,
         ignore_value2text_conversion: bool = True,
     ) -> Signal:
-        """get LIN message signal. You can specify an external LIN database (
-        *database* argument) or canmatrix database object that has already been
-        loaded from a file (*db* argument).
+        """Get LIN message signal. You can specify an external LIN database path
+        or a canmatrix database object that has already been loaded from a file.
 
         The signal name can be specified in the following ways
 

--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -194,13 +194,13 @@ class MDF4(MDF_Common):
     * ``channel_dependencies`` - list of *ChannelArrayBlock* in case of channel arrays;
       list of Channel objects in case of structure channel composition
     * ``data_block`` - address of data block
-    * ``data_location``- integer code for data location (original file, temporary file or
+    * ``data_location`` - integer code for data location (original file, temporary file or
       memory)
     * ``data_block_addr`` - list of raw samples starting addresses
     * ``data_block_type`` - list of codes for data block type
     * ``data_block_size`` - list of raw samples block size
     * ``sorted`` - sorted indicator flag
-    * ``record_size`` - dict that maps record ID's to record sizes in bytes (including invalidation bytes)
+    * ``record_size`` - dict that maps record IDs to record sizes in bytes (including invalidation bytes)
     * ``param`` - row size used for transposition, in case of transposed zipped blocks
 
 
@@ -2638,7 +2638,7 @@ class MDF4(MDF_Common):
         pos_invalidation_bit: int,
         fragment: tuple[bytes, int, int, ReadableBufferType | None],
     ) -> NDArray[bool_]:
-        """get invalidation indexes for the channel
+        """Get invalidation indexes for the channel.
 
         Parameters
         ----------
@@ -2699,8 +2699,7 @@ class MDF4(MDF_Common):
         common_timebase: bool = False,
         units: dict[str, str | bytes] | None = None,
     ) -> int | None:
-        """
-        Appends a new data group.
+        """Appends a new data group.
 
         For channel dependencies type Signals, the *samples* attribute must be
         a numpy.recarray
@@ -4722,10 +4721,7 @@ class MDF4(MDF_Common):
         comment: str | None = None,
         units: dict[str, str | bytes] | None = None,
     ) -> None:
-        """
-        Appends a new data group from a Pandas data frame.
-
-        """
+        """Appends a new data group from a Pandas DataFrame."""
         units = units or {}
 
         if df.shape == (0, 0):
@@ -5869,8 +5865,7 @@ class MDF4(MDF_Common):
         return offset, dg_cntr, ch_cntr, struct_self, fields, types
 
     def extend(self, index: int, signals: list[tuple[NDArray[Any], NDArray[Any] | None]]) -> None:
-        """
-        Extend a group with new samples. *signals* contains (values, invalidation_bits)
+        """Extend a group with new samples. *signals* contains (values, invalidation_bits)
         pairs for each extended signal. The first pair is the master channel's pair, and the
         next pairs must respect the same order in which the signals were appended. The samples must have raw
         or physical values according to the *Signals* used for the initial append.
@@ -5880,7 +5875,7 @@ class MDF4(MDF_Common):
         index : int
             group index
         signals : list
-            list on (numpy.ndarray, numpy.ndarray) objects
+            list of (numpy.ndarray, numpy.ndarray) objects
 
         Examples
         --------
@@ -6158,8 +6153,7 @@ class MDF4(MDF_Common):
                     )
 
     def _extend_column_oriented(self, index: int, signals: list[tuple[NDArray[Any], NDArray[Any] | None]]) -> None:
-        """
-        Extend a group with new samples. *signals* contains (values, invalidation_bits)
+        """Extend a group with new samples. *signals* contains (values, invalidation_bits)
         pairs for each extended signal. The first pair is the master channel's pair, and the
         next pairs must respect the same order in which the signals were appended. The samples must have raw
         or physical values according to the *Signals* used for the initial append.
@@ -6169,7 +6163,7 @@ class MDF4(MDF_Common):
         index : int
             group index
         signals : list
-            list on (numpy.ndarray, numpy.ndarray) objects
+            list of (numpy.ndarray, numpy.ndarray) objects
 
         Examples
         --------
@@ -6311,7 +6305,7 @@ class MDF4(MDF_Common):
         embedded: bool = True,
         password: str | bytes | None = None,
     ) -> int:
-        """attach embedded attachment as application/octet-stream.
+        """Attach embedded attachment as application/octet-stream.
 
         Parameters
         ----------
@@ -6442,9 +6436,10 @@ class MDF4(MDF_Common):
         return index
 
     def close(self) -> None:
-        """if the MDF was created with memory=False and new
+        """If the MDF was created with memory=False and new
         channels have been appended, then this must be called just before the
-        object is not used anymore to clean-up the temporary file"""
+        object is not used anymore to clean-up the temporary file.
+        """
 
         if self._closed:
             return
@@ -6703,7 +6698,7 @@ class MDF4(MDF_Common):
             time raster in seconds
         samples_only : bool
             if *True* return only the channel samples as numpy array; if
-                *False* return a *Signal* object
+            *False* return a *Signal* object
         data : bytes
             prevent redundant data read by providing the raw data group samples
         raw : bool
@@ -6718,7 +6713,7 @@ class MDF4(MDF_Common):
             number of records to read; default *None* and in this case all
             available records are used
         skip_channel_validation (False) : bool
-            skip validation of channel name, group index and channel index; defualt
+            skip validation of channel name, group index and channel index; default
             *False*. If *True*, the caller has to make sure that the *group* and *index*
             arguments are provided and are correct.
 
@@ -8592,14 +8587,14 @@ class MDF4(MDF_Common):
         record_count: int | None = None,
         one_piece: bool = False,
     ) -> NDArray[Any]:
-        """returns master channel samples for given group
+        """Returns master channel samples for given group.
 
         Parameters
         ----------
         index : int
             group index
         data : (bytes, int, int, bytes|None)
-            (data block raw bytes, fragment offset, count, invalidation bytes); default None
+            (data block raw bytes, fragment offset, count, invalidation bytes); default *None*
 
         record_offset : int
             if *data=None* use this to select the record offset from which the
@@ -8791,9 +8786,9 @@ class MDF4(MDF_Common):
         raw: bool = False,
         ignore_value2text_conversion: bool = True,
     ) -> Signal:
-        """get a signal decoded from a raw bus logging. The currently supported buses are
+        """Get a signal decoded from a raw bus logging. The currently supported buses are
         CAN and LIN (LDF databases are not supported, they need to be converted to DBC and
-        feed to this function)
+        fed to this function).
 
         .. versionadded:: 6.0.0
 
@@ -8816,8 +8811,8 @@ class MDF4(MDF_Common):
             return channel samples without applying the conversion rule; default
             `False`
         ignore_value2text_conversion : bool
-            return channel samples without values that have a description in .dbc or .arxml file
-            `True`
+            return channel samples without values that have a description in .dbc or .arxml file;
+            default `True`
 
         Returns
         -------
@@ -8898,8 +8893,8 @@ class MDF4(MDF_Common):
             return channel samples without applying the conversion rule; default
             `False`
         ignore_value2text_conversion : bool
-            return channel samples without values that have a description in .dbc or .arxml file
-            `True`
+            return channel samples without values that have a description in .dbc or .arxml file;
+            default `True`
 
         Returns
         -------
@@ -9154,8 +9149,8 @@ class MDF4(MDF_Common):
             return channel samples without applying the conversion rule; default
             `False`
         ignore_value2text_conversion : bool
-            return channel samples without values that have a description in .dbc, .arxml or .ldf file
-            `True`
+            return channel samples without values that have a description in .dbc, .arxml or .ldf file;
+            default `True`
 
         Returns
         -------
@@ -9293,7 +9288,7 @@ class MDF4(MDF_Common):
         raise MdfException(f'No logging from "{signal}" was found in the measurement')
 
     def info(self) -> dict[str, Any]:
-        """get MDF information as a dict
+        """Get MDF information as a dict.
 
         Examples
         --------
@@ -9322,7 +9317,7 @@ class MDF4(MDF_Common):
 
     @property
     def start_time(self) -> datetime:
-        """getter and setter the measurement start timestamp
+        """Getter and setter of the measurement start timestamp.
 
         Returns
         -------
@@ -9348,12 +9343,12 @@ class MDF4(MDF_Common):
         """Save MDF to *dst*. If overwrite is *True* then the destination file
         is overwritten, otherwise the file name is appended with '.<cntr>', were
         '<cntr>' is the first counter that produces a new file name
-        (that does not already exist in the filesystem)
+        (that does not already exist in the filesystem).
 
         Parameters
         ----------
         dst : str
-            destination file name, Default ''
+            destination file name
         overwrite : bool
             overwrite flag, default *False*
         compression : int
@@ -9365,7 +9360,7 @@ class MDF4(MDF_Common):
               the smallest files)
 
         add_history_block : bool
-            option to add file historyu block
+            option to add file history block
 
         Returns
         -------

--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -2727,31 +2727,30 @@ class MDF4(MDF_Common):
 
         Examples
         --------
+        >>> from asammdf import MDF, Signal
+        >>> import numpy as np
+
         >>> # case 1 conversion type None
         >>> s1 = np.array([1, 2, 3, 4, 5])
         >>> s2 = np.array([-1, -2, -3, -4, -5])
         >>> s3 = np.array([0.1, 0.04, 0.09, 0.16, 0.25])
         >>> t = np.array([0.001, 0.002, 0.003, 0.004, 0.005])
-        >>> names = ['Positive', 'Negative', 'Float']
-        >>> units = ['+', '-', '.f']
-        >>> info = {}
         >>> s1 = Signal(samples=s1, timestamps=t, unit='+', name='Positive')
         >>> s2 = Signal(samples=s2, timestamps=t, unit='-', name='Negative')
         >>> s3 = Signal(samples=s3, timestamps=t, unit='flts', name='Floats')
-        >>> mdf = MDF4('new.mdf')
-        >>> mdf.append([s1, s2, s3], comment='created by asammdf v4.0.0')
+        >>> mdf = MDF(version='4.10')
+        >>> mdf.append([s1, s2, s3], comment='created by asammdf')
+
         >>> # case 2: VTAB conversions from channels inside another file
-        >>> mdf1 = MDF4('in.mf4')
+        >>> mdf1 = MDF('in.mf4')
         >>> ch1 = mdf1.get("Channel1_VTAB")
         >>> ch2 = mdf1.get("Channel2_VTABR")
-        >>> sigs = [ch1, ch2]
-        >>> mdf2 = MDF4('out.mf4')
-        >>> mdf2.append(sigs, comment='created by asammdf v4.0.0')
+        >>> mdf2 = MDF('out.mf4')
+        >>> mdf2.append([ch1, ch2], comment='created by asammdf')
         >>> mdf2.append(ch1, comment='just a single channel')
         >>> df = pd.DataFrame.from_dict({'s1': np.array([1, 2, 3, 4, 5]), 's2': np.array([-1, -2, -3, -4, -5])})
         >>> units = {'s1': 'V', 's2': 'A'}
         >>> mdf2.append(df, units=units)
-
         """
         source_block = SourceInformation.from_common_source(acq_source) if acq_source else acq_source
 
@@ -5885,25 +5884,25 @@ class MDF4(MDF_Common):
 
         Examples
         --------
-        >>> # case 1 conversion type None
+        >>> from asammdf import MDF, Signal
+        >>> import numpy as np
         >>> s1 = np.array([1, 2, 3, 4, 5])
         >>> s2 = np.array([-1, -2, -3, -4, -5])
         >>> s3 = np.array([0.1, 0.04, 0.09, 0.16, 0.25])
         >>> t = np.array([0.001, 0.002, 0.003, 0.004, 0.005])
-        >>> names = ['Positive', 'Negative', 'Float']
-        >>> units = ['+', '-', '.f']
         >>> s1 = Signal(samples=s1, timestamps=t, unit='+', name='Positive')
         >>> s2 = Signal(samples=s2, timestamps=t, unit='-', name='Negative')
         >>> s3 = Signal(samples=s3, timestamps=t, unit='flts', name='Floats')
-        >>> mdf = MDF4('new.mdf')
-        >>> mdf.append([s1, s2, s3], comment='created by asammdf v1.1.0')
+        >>> mdf = MDF(version='4.10')
+        >>> mdf.append([s1, s2, s3], comment='created by asammdf')
         >>> t = np.array([0.006, 0.007, 0.008, 0.009, 0.010])
-        >>> # extend without invalidation bits
-        >>> mdf2.extend(0, [(t, None), (s1, None), (s2, None), (s3, None)])
-        >>> # some invaldiation btis
-        >>> s1_inv = np.array([0,0,0,1,1], dtype=np.bool)
-        >>> mdf2.extend(0, [(t, None), (s1.samples, None), (s2.samples, None), (s3.samples, None)])
 
+        >>> # extend without invalidation bits
+        >>> mdf.extend(0, [(t, None), (s1.samples, None), (s2.samples, None), (s3.samples, None)])
+
+        >>> # some invalidation bits
+        >>> s1_inv = np.array([0, 0, 0, 1, 1], dtype=np.bool)
+        >>> mdf.extend(0, [(t, None), (s1.samples, s1_inv), (s2.samples, None), (s3.samples, None)])
         """
         if self.version >= "4.20" and (self._column_storage or 1):
             return self._extend_column_oriented(index, signals)
@@ -6174,25 +6173,25 @@ class MDF4(MDF_Common):
 
         Examples
         --------
-        >>> # case 1 conversion type None
+        >>> from asammdf import MDF, Signal
+        >>> import numpy as np
         >>> s1 = np.array([1, 2, 3, 4, 5])
         >>> s2 = np.array([-1, -2, -3, -4, -5])
         >>> s3 = np.array([0.1, 0.04, 0.09, 0.16, 0.25])
         >>> t = np.array([0.001, 0.002, 0.003, 0.004, 0.005])
-        >>> names = ['Positive', 'Negative', 'Float']
-        >>> units = ['+', '-', '.f']
         >>> s1 = Signal(samples=s1, timestamps=t, unit='+', name='Positive')
         >>> s2 = Signal(samples=s2, timestamps=t, unit='-', name='Negative')
         >>> s3 = Signal(samples=s3, timestamps=t, unit='flts', name='Floats')
-        >>> mdf = MDF4('new.mdf')
-        >>> mdf.append([s1, s2, s3], comment='created by asammdf v1.1.0')
+        >>> mdf = MDF(version='4.10')
+        >>> mdf.append([s1, s2, s3], comment='created by asammdf')
         >>> t = np.array([0.006, 0.007, 0.008, 0.009, 0.010])
-        >>> # extend without invalidation bits
-        >>> mdf2.extend(0, [(t, None), (s1, None), (s2, None), (s3, None)])
-        >>> # some invaldiation btis
-        >>> s1_inv = np.array([0,0,0,1,1], dtype=np.bool)
-        >>> mdf2.extend(0, [(t, None), (s1.samples, None), (s2.samples, None), (s3.samples, None)])
 
+        >>> # extend without invalidation bits
+        >>> mdf.extend(0, [(t, None), (s1.samples, None), (s2.samples, None), (s3.samples, None)])
+
+        >>> # some invalidation bits
+        >>> s1_inv = np.array([0, 0, 0, 1, 1], dtype=np.bool)
+        >>> mdf.extend(0, [(t, None), (s1.samples, s1_inv), (s2.samples, None), (s3.samples, None)])
         """
         gp = self.groups[index]
         if not signals:
@@ -6749,6 +6748,9 @@ class MDF4(MDF_Common):
         * if the channel name is not found
         * if the group index is out of range
         * if the channel index is out of range
+        * if there are multiple channel occurrences in the file and the arguments
+          *name*, *group*, *index* are ambiguous. This behaviour can be turned off
+          by setting raise_on_multiple_occurrences to *False*.
 
         Examples
         --------
@@ -6761,49 +6763,37 @@ class MDF4(MDF_Common):
         ...     sigs = [Signal(s*(i*10+j), t, name='Sig') for j in range(1, 4)]
         ...     mdf.append(sigs)
         ...
-        >>> # first group and channel index of the specified channel name
-        ...
         >>> mdf.get('Sig')
-        UserWarning: Multiple occurrences for channel "Sig". Using first occurrence from data group 4. Provide both "group" and "index" arguments to select another data group
-        <Signal Sig:
-                samples=[ 1.  1.  1.  1.  1.]
-                timestamps=[0 1 2 3 4]
-                unit=""
-                info=None
-                comment="">
-        >>> # first channel index in the specified group
-        ...
+        MdfException: Multiple occurrences for channel "Sig": ((0, 1), (0, 2),
+        (0, 3), (1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3), (3, 1), (3, 2),
+        (3, 3)). Provide both "group" and "index" arguments to select another
+        data group
+        >>>
         >>> mdf.get('Sig', 1)
-        <Signal Sig:
-                samples=[ 11.  11.  11.  11.  11.]
-                timestamps=[0 1 2 3 4]
-                unit=""
-                info=None
-                comment="">
-        >>> # channel named Sig from group 1 channel index 2
-        ...
+        MdfException: Multiple occurrences for channel "Sig": ((1, 1), (1, 2),
+        (1, 3)). Provide both "group" and "index" arguments to select another
+        data group
+        >>>
+        >>> # channel named Sig from group 1, channel index 2
         >>> mdf.get('Sig', 1, 2)
         <Signal Sig:
                 samples=[ 12.  12.  12.  12.  12.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
-        >>> # channel index 1 or group 2
-        ...
+        >>>
+        >>> # group 2, channel index 1
         >>> mdf.get(None, 2, 1)
         <Signal Sig:
                 samples=[ 21.  21.  21.  21.  21.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         >>> mdf.get(group=2, index=1)
         <Signal Sig:
                 samples=[ 21.  21.  21.  21.  21.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
 
         """
@@ -9309,10 +9299,8 @@ class MDF4(MDF_Common):
 
         Examples
         --------
-        >>> mdf = MDF4('test.mdf')
+        >>> mdf = MDF('test.mdf')
         >>> mdf.info()
-
-
         """
         info = {
             "version": self.version,

--- a/src/asammdf/blocks/source_utils.py
+++ b/src/asammdf/blocks/source_utils.py
@@ -34,7 +34,7 @@ class Source:
     BUS_TYPE_USB = v4c.BUS_TYPE_USB
 
     def __init__(self, name: str, path: str, comment: str, source_type: int, bus_type: int) -> None:
-        """Commons reprezentation for source information
+        """Common representation for source information.
 
         Attributes
         ----------

--- a/src/asammdf/blocks/v2_v3_blocks.py
+++ b/src/asammdf/blocks/v2_v3_blocks.py
@@ -2877,7 +2877,7 @@ class HeaderBlock:
 
     @property
     def start_time(self) -> datetime:
-        """getter and setter the measurement start timestamp
+        """Getter and setter of the measurement start timestamp.
 
         Returns
         -------

--- a/src/asammdf/blocks/v4_blocks.py
+++ b/src/asammdf/blocks/v4_blocks.py
@@ -5440,7 +5440,7 @@ class FileHistory:
 
     @property
     def time_stamp(self) -> datetime:
-        """getter and setter the file history timestamp
+        """Getter and setter of the file history timestamp.
 
         Returns
         -------
@@ -5733,7 +5733,7 @@ class HeaderBlock:
 
     @property
     def start_time(self) -> datetime:
-        """getter and setter the measurement start timestamp
+        """Getter and setter of the measurement start timestamp.
 
         Returns
         -------

--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -2013,6 +2013,7 @@ class MDF:
         >>> t = np.arange(5)
         >>> s = np.ones(5)
         >>> mdf = MDF()
+        >>> mdf.configure(raise_on_multiple_occurrences=False)
         >>> for i in range(4):
         ...     sigs = [Signal(s*(i*10+j), t, name='SIG') for j in range(1,4)]
         ...     mdf.append(sigs)
@@ -2025,25 +2026,21 @@ class MDF:
                 samples=[ 1.  1.  1.  1.  1.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         <Signal SIG:
                 samples=[ 31.  31.  31.  31.  31.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         <Signal SIG:
                 samples=[ 21.  21.  21.  21.  21.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         <Signal SIG:
                 samples=[ 12.  12.  12.  12.  12.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
 
         """
@@ -2262,6 +2259,15 @@ class MDF:
 
                 .. versionadded:: 8.1.0
 
+        Returns
+        -------
+        concatenate : MDF
+            new *MDF* object with concatenated channels
+
+        Raises
+        ------
+        MdfException : if there are inconsistencies between the files
+
         Examples
         --------
         >>> conc = MDF.concatenate(
@@ -2275,15 +2281,6 @@ class MDF:
             version='4.00',
             sync=False,
         )
-
-        Returns
-        -------
-        concatenate : MDF
-            new *MDF* object with concatenated channels
-
-        Raises
-        ------
-        MdfException : if there are inconsistencies between the files
 
         """
 
@@ -2703,6 +2700,11 @@ class MDF:
 
                 .. versionadded:: 8.1.0
 
+        Returns
+        -------
+        stacked : MDF
+            new *MDF* object with stacked channels
+
         Examples
         --------
         >>> stacked = MDF.stack(
@@ -2716,11 +2718,6 @@ class MDF:
             version='4.00',
             sync=False,
         )
-
-        Returns
-        -------
-        stacked : MDF
-            new *MDF* object with stacked channels
 
         """
         if not files:
@@ -3074,6 +3071,7 @@ class MDF:
                 display_names={}
                 attachment=()>
         ]
+
         >>> resampled = mdf.resample(raster='S2')
         >>> resampled.select(['S1', 'S2'])
         [<Signal S1:
@@ -3101,6 +3099,7 @@ class MDF:
                 display_names={}
                 attachment=()>
         ]
+
         >>> resampled = mdf.resample(raster=[1.9, 2.0, 2.1])
         >>> resampled.select(['S1', 'S2'])
         [<Signal S1:
@@ -3128,6 +3127,7 @@ class MDF:
                 display_names={}
                 attachment=()>
         ]
+
         >>> resampled = mdf.resample(raster='S2', time_from_zero=True)
         >>> resampled.select(['S1', 'S2'])
         [<Signal S1:
@@ -3316,6 +3316,7 @@ class MDF:
         >>> t = np.arange(5)
         >>> s = np.ones(5)
         >>> mdf = MDF()
+        >>> mdf.configure(raise_on_multiple_occurrences=False)
         >>> for i in range(4):
         ...     sigs = [Signal(s*(i*10+j), t, name='SIG') for j in range(1,4)]
         ...     mdf.append(sigs)
@@ -3327,25 +3328,21 @@ class MDF:
                 samples=[ 1.  1.  1.  1.  1.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         , <Signal SIG:
                 samples=[ 31.  31.  31.  31.  31.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         , <Signal SIG:
                 samples=[ 21.  21.  21.  21.  21.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         , <Signal SIG:
                 samples=[ 12.  12.  12.  12.  12.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         ]
 
@@ -3618,6 +3615,7 @@ class MDF:
         >>> t = np.arange(5)
         >>> s = np.ones(5)
         >>> mdf = MDF()
+        >>> mdf.configure(raise_on_multiple_occurrences=False)
         >>> for i in range(4):
         ...     sigs = [Signal(s*(i*10+j), t, name='SIG') for j in range(1,4)]
         ...     mdf.append(sigs)
@@ -3629,25 +3627,21 @@ class MDF:
                 samples=[ 1.  1.  1.  1.  1.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         , <Signal SIG:
                 samples=[ 31.  31.  31.  31.  31.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         , <Signal SIG:
                 samples=[ 21.  21.  21.  21.  21.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         , <Signal SIG:
                 samples=[ 12.  12.  12.  12.  12.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         ]
 
@@ -5121,20 +5115,20 @@ class MDF:
 
         Examples
         --------
-        >>> "extrac CAN and LIN bus logging"
+        >>> "extract CAN and LIN bus logging"
         >>> mdf = asammdf.MDF(r'bus_logging.mf4')
         >>> databases = {
         ...     "CAN": [("file1.dbc", 0), ("file2.arxml", 2)],
         ...     "LIN": [("file3.dbc", 0)],
         ... }
-        >>> extracted = mdf.extract_bus_logging(database_files=database_files)
-        >>> ...
-        >>> "extrac just LIN bus logging"
+        >>> extracted = mdf.extract_bus_logging(database_files=databases)
+
+        >>> "extract just LIN bus logging"
         >>> mdf = asammdf.MDF(r'bus_logging.mf4')
         >>> databases = {
         ...     "LIN": [("file3.dbc", 0)],
         ... }
-        >>> extracted = mdf.extract_bus_logging(database_files=database_files)
+        >>> extracted = mdf.extract_bus_logging(database_files=databases)
 
         """
         if ignore_invalid_signals is not None:

--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -875,7 +875,7 @@ class MDF:
             case the original file version is used
         include_ends : bool
             include the *start* and *stop* timestamps after cutting the signal.
-            If *start* and *stop* are found in the original timestamps, then
+            If *start* and *stop* are not found in the original timestamps, then
             the new samples will be computed using interpolation. Default *True*
         time_from_zero : bool
             start time stamps from 0s in the cut measurement

--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -2875,12 +2875,12 @@ class MDF:
             do not yield master channels; default *True*
         copy_master : bool
             copy master for each yielded channel *True*
-        raw : bool
+        raw : bool | dict[str, bool]
             return raw channels instead of converted; default *False*
 
             .. versionchanged:: 8.0.0
 
-                provide individual raw mode based on a dict. If the parameters is given
+                provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
 
@@ -2935,14 +2935,14 @@ class MDF:
 
             .. versionadded:: 5.21.0
 
-        raw (False) : bool
-            the dataframe will contain the raw channel values
+        raw : bool | dict[str, bool]
+            the DataFrame will contain the raw channel values; default *False*
 
             .. versionadded:: 5.21.0
 
             .. versionchanged:: 8.0.0
 
-                provide individual raw mode based on a dict. If the parameters is given
+                provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
 
@@ -3285,7 +3285,7 @@ class MDF:
 
             .. versionchanged:: 8.0.0
 
-                provide individual raw mode based on a dict. If the parameters is given
+                provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
 
@@ -3584,7 +3584,7 @@ class MDF:
 
             .. versionchanged:: 8.0.0
 
-                provide individual raw mode based on a dict. If the parameters is given
+                provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
 
@@ -4141,14 +4141,14 @@ class MDF:
             reduce memory usage by converting all float columns to float32 and
             searching for minimum dtype that can reprezent the values found
             in integer columns; default *False*
-        raw (False) : bool | dict[str, bool]
-            the dataframe will contain the raw channel values
+        raw : bool | dict[str, bool]
+            the DataFrame will contain the raw channel values; default *False*
 
             .. versionadded:: 5.7.0
 
             .. versionchanged:: 8.0.0
 
-                provide individual raw mode based on a dict. If the parameters is given
+                provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
 
@@ -4280,12 +4280,12 @@ class MDF:
             reduce memory usage by converting all float columns to float32 and
             searching for minimum dtype that can reprezent the values found
             in integer columns; default *False*
-        raw (False) : bool
-            the columns will contain the raw values
+        raw : bool | dict[str, bool]
+            the columns will contain the raw values; default *False*
 
             .. versionchanged:: 8.0.0
 
-                provide individual raw mode based on a dict. If the parameters is given
+                provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
 
@@ -4690,14 +4690,14 @@ class MDF:
             reduce memory usage by converting all float columns to float32 and
             searching for minimum dtype that can reprezent the values found
             in integer columns; default *False*
-        raw (False) : bool
-            the columns will contain the raw values
+        raw : bool | dict[str, bool]
+            the columns will contain the raw values; default *False*
 
             .. versionadded:: 5.7.0
 
             .. versionchanged:: 8.0.0
 
-                provide individual raw mode based on a dict. If the parameters is given
+                provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
 

--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -166,7 +166,7 @@ class MDF:
     ----------
     name : string | BytesIO | zipfile.ZipFile | bz2.BZ2File | gzip.GzipFile
         mdf file name (if provided it must be a real file name), file-like object or
-        compressed file opened as Python object
+        compressed file opened as a Python object
 
         .. versionchanged:: 6.2.0
 
@@ -179,29 +179,29 @@ class MDF:
         from a file the version is set to file version
 
     channels (None) : iterable
-        channel names that will used for selective loading. This can dramatically
-        improve the file loading time. Default None -> load all channels
+        channel names that will be used for selective loading. This can dramatically
+        improve the file loading time. Default *None* -> load all channels
 
         .. versionadded:: 6.1.0
 
-        .. versionchanged:: 6.3.0 make the default None
+        .. versionchanged:: 6.3.0 make the default *None*
 
     use_display_names (\*\*kwargs) : bool
-        keyword only argument: for MDF4 files parse the XML channel comment to
+        keyword-only argument: for MDF v4 files, parse the XML channel comment to
         search for the display name; XML parsing is quite expensive so setting
         this to *False* can decrease the loading times very much; default
         *True*
     remove_source_from_channel_names (\*\*kwargs) : bool
         remove source from channel names ("Speed\XCP3" -> "Speed")
     copy_on_get (\*\*kwargs) : bool
-        copy arrays in the get method; default *True*
+        copy arrays in the `get` method; default *True*
     expand_zippedfile (\*\*kwargs) : bool
         only for bz2.BZ2File and gzip.GzipFile, load the file content into a
         BytesIO before parsing (avoids the huge performance penalty of doing
         random reads from the zipped file); default *True*
     raise_on_multiple_occurrences (\*\*kwargs) : bool
-        raise exception when there are multiple channel occurrences in the file and
-        the `get` call is ambiguous; default True
+        raise MdfException when there are multiple channel occurrences in the file and
+        the `get` call is ambiguous; default *True*
 
         .. versionadded:: 7.0.0
 
@@ -211,7 +211,7 @@ class MDF:
         .. versionadded:: 7.0.0
 
     process_bus_logging (\*\*kwargs) : bool
-        controls if the bus processing of MDF v4 files is done when the file is loaded. Default True
+        controls if the bus processing of MDF v4 files is done when the file is loaded. Default *True*
 
         .. versionadded:: 8.0.0
 
@@ -651,9 +651,10 @@ class MDF:
         temporary_folder: str | None = None,
         fill_0_for_missing_computation_channels: bool | None = None,
     ) -> None:
-        """configure MDF parameters
+        """Configure *MDF* parameters.
 
         The default values for the options are the following:
+
         * read_fragment_size = 0
         * write_fragment_size = 4MB
         * use_display_names = False
@@ -679,7 +680,7 @@ class MDF:
         use_display_names : bool
             search for display name in the Channel XML comment
         single_bit_uint_as_bool : bool
-            return single bit channels are np.bool arrays
+            return single bit channels as np.bool arrays
         integer_interpolation : int
             interpolation mode for integer channels:
 
@@ -704,8 +705,8 @@ class MDF:
                 .. versionadded:: 6.2.0
 
         raise_on_multiple_occurrences : bool
-            raise exception when there are multiple channel occurrences in the file and
-            the `get` call is ambiguous; default True
+            raise MdfException when there are multiple channel occurrences in the file and
+            the `get` call is ambiguous; default *True*
 
             .. versionadded:: 6.2.0
 
@@ -721,7 +722,7 @@ class MDF:
 
         fill_0_for_missing_computation_channels : bool
             when a channel required by a computed channel is missing, then fill with 0 values.
-            If false then the computation will fail and the computed channel will be marked as not existing.
+            If *False* then the computation will fail and the computed channel will be marked as not existing.
 
             .. versionadded:: 7.1.0
         """
@@ -768,7 +769,7 @@ class MDF:
             self._raise_on_multiple_occurrences = bool(raise_on_multiple_occurrences)
 
     def convert(self, version: str, progress=None) -> MDF:
-        """convert *MDF* to other version
+        """Convert *MDF* to other version.
 
         Parameters
         ----------
@@ -851,7 +852,7 @@ class MDF:
         time_from_zero: bool = False,
         progress=None,
     ) -> MDF:
-        """cut *MDF* file. *start* and *stop* limits are absolute values
+        """Cut *MDF* file. *start* and *stop* limits are absolute values
         or values relative to the first timestamp depending on the *whence*
         argument.
 
@@ -878,12 +879,12 @@ class MDF:
             If *start* and *stop* are not found in the original timestamps, then
             the new samples will be computed using interpolation. Default *True*
         time_from_zero : bool
-            start time stamps from 0s in the cut measurement
+            start timestamps from 0s in the cut measurement
 
         Returns
         -------
         out : MDF
-            new MDF object
+            new *MDF* object
 
         """
 
@@ -1114,10 +1115,10 @@ class MDF:
         progress=None,
         **kwargs,
     ) -> None:
-        r"""export *MDF* to other formats. The *MDF* file name is used is
+        r"""Export *MDF* to other formats. The *MDF* file name is used if
         available, else the *filename* argument must be provided.
 
-        The *pandas* export option was removed. you should use the method
+        The *pandas* export option was removed. You should use the method
         *to_dataframe* instead.
 
         Parameters
@@ -1167,7 +1168,7 @@ class MDF:
               prefixed with the parent channel.
             * `reduce_memory_usage` : bool
               reduce memory usage by converting all float columns to float32 and
-              searching for minimum dtype that can reprezent the values found
+              searching for minimum dtype that can represent the values found
               in integer columns; default *False*
             * `compression` : str
               compression to be used
@@ -1181,13 +1182,13 @@ class MDF:
                 added LZ4 compression after changing to pyarrow
 
             * `time_as_date` (False) : bool
-              export time as local timezone datetimee; only valid for CSV export
+              export time as local timezone datetime; only valid for CSV export
 
               .. versionadded:: 5.8.0
 
             * `ignore_value2text_conversions` (False) : bool
               valid only for the channels that have value to text conversions and
-              if *raw=False*. If this is True then the raw numeric values will be
+              if *raw=False*. If this is *True* then the raw numeric values will be
               used, and the conversion will not be applied.
 
               .. versionadded:: 5.8.0
@@ -1983,8 +1984,8 @@ class MDF:
             logger.warning(message)
 
     def filter(self, channels: ChannelsType, version: str | None = None, progress=None) -> MDF:
-        """return new *MDF* object that contains only the channels listed in
-        *channels* argument
+        """Return new *MDF* object that contains only the channels listed in the
+        *channels* argument.
 
         Parameters
         ----------
@@ -2165,12 +2166,12 @@ class MDF:
         samples_only: bool = False,
         raw: bool = False,
     ) -> Iterator[Signal] | Iterator[tuple[NDArray[Any], NDArray[Any] | None]]:
-        """iterator over a channel
+        """Iterator over a channel.
 
         This is usefull in case of large files with a small number of channels.
 
         If the *raster* keyword argument is not *None* the output is
-        interpolated accordingly
+        interpolated accordingly.
 
         Parameters
         ----------
@@ -2184,10 +2185,10 @@ class MDF:
             time raster in seconds
         samples_only : bool
             if *True* return only the channel samples as numpy array; if
-                *False* return a *Signal* object
+            *False* return a *Signal* object
         raw : bool
-            return channel samples without appling the conversion rule; default
-            `False`
+            return channel samples without applying the conversion rule; default
+            *False*
 
         """
 
@@ -2218,11 +2219,10 @@ class MDF:
         progress=None,
         **kwargs,
     ) -> MDF:
-        """concatenates several files. The files
-        must have the same internal structure (same number of groups, and same
-        channels in each group).
+        """Concatenates several files. The files must have the same internal
+        structure (same number of groups, and same channels in each group).
 
-        The order of the input files is always preserved, only the samples timestamps are influenced
+        The order of the input files is always preserved, only the samples' timestamps are influenced
         by the ``sync`` argument.
 
         Parameters
@@ -2239,14 +2239,14 @@ class MDF:
             merged file version
         sync : bool
             sync the files based on the start of measurement, default *True*. The order of the
-            input files is preserved, only the samples timestamps are influenced by this
+            input files is preserved, only the samples' timestamps are influenced by this
             argument
         add_samples_origin : bool
             option to create a new "__samples_origin" channel that will hold
             the index of the measurement from where each timestamp originated
         direct_timestamp_continuation (False) : bool
-            the time stamps from the next file will be added right after the last
-            time stamp from the previous file; default False
+            the timestamps from the next file will be added right after the last
+            timestamp from the previous file; default *False*
 
             ..versionadded:: 6.0.0
 
@@ -2255,7 +2255,7 @@ class MDF:
             use_display_names (False) : bool
 
             process_bus_logging (True) : bool
-                controls if the bus processing of MDF v4 files is done when the file is loaded. Default True
+                controls if the bus processing of MDF v4 files is done when the file is loaded. Default *True*
 
                 .. versionadded:: 8.1.0
 
@@ -2675,7 +2675,7 @@ class MDF:
         progress=None,
         **kwargs,
     ) -> MDF:
-        """stack several files and return the stacked *MDF* object
+        """Stack several files and return the stacked *MDF* object.
 
         Parameters
         ----------
@@ -2696,7 +2696,7 @@ class MDF:
             use_display_names (False) : bool
 
             process_bus_logging (True) : bool
-                controls if the bus processing of MDF v4 files is done when the file is loaded. Default True
+                controls if the bus processing of MDF v4 files is done when the file is loaded. Default *True*
 
                 .. versionadded:: 8.1.0
 
@@ -2867,14 +2867,14 @@ class MDF:
         copy_master: bool = True,
         raw: bool | dict[str, bool] = False,
     ) -> Iterator[Signal]:
-        """generator that yields a *Signal* for each non-master channel
+        """Generator that yields a *Signal* for each non-master channel.
 
         Parameters
         ----------
         skip_master : bool
             do not yield master channels; default *True*
         copy_master : bool
-            copy master for each yielded channel *True*
+            copy master for each yielded channel; default *True*
         raw : bool | dict[str, bool]
             return raw channels instead of converted; default *False*
 
@@ -2883,8 +2883,6 @@ class MDF:
                 provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
-
-
         """
 
         if isinstance(raw, dict):
@@ -2915,11 +2913,10 @@ class MDF:
         ignore_value2text_conversions: bool = False,
         only_basenames: bool = False,
     ) -> Iterator[pd.DataFrame]:
-        """generator that yields channel groups as pandas DataFrames. If there
+        """Generator that yields channel groups as pandas DataFrames. If there
         are multiple occurrences for the same channel name inside a channel
         group, then a counter will be used to make the names unique
-        (<original_name>_<counter>)
-
+        (<original_name>_<counter>).
 
         Parameters
         ----------
@@ -2930,7 +2927,7 @@ class MDF:
 
         reduce_memory_usage : bool
             reduce memory usage by converting all float columns to float32 and
-            searching for minimum dtype that can reprezent the values found
+            searching for minimum dtype that can represent the values found
             in integer columns; default *False*
 
             .. versionadded:: 5.21.0
@@ -2948,7 +2945,7 @@ class MDF:
 
         ignore_value2text_conversions (False) : bool
             valid only for the channels that have value to text conversions and
-            if *raw=False*. If this is True then the raw numeric values will be
+            if *raw=False*. If this is *True* then the raw numeric values will be
             used, and the conversion will not be applied.
 
             .. versionadded:: 5.21.0
@@ -2977,7 +2974,7 @@ class MDF:
             new raster that can be
 
             * a float step value
-            * a channel name who's timestamps will be used as raster (starting with asammdf 5.5.0)
+            * a channel name whose timestamps will be used as raster (starting with asammdf 5.5.0)
             * an array (starting with asammdf 5.5.0)
 
             see `resample` for examples of using this argument
@@ -3008,8 +3005,8 @@ class MDF:
         time_from_zero: bool = False,
         progress=None,
     ) -> MDF:
-        """resample all channels using the given raster. See *configure* to select
-        the interpolation method for interger channels
+        """Resample all channels using the given raster. See *configure* to select
+        the interpolation method for integer channels.
 
         Parameters
         ----------
@@ -3017,7 +3014,7 @@ class MDF:
             new raster that can be
 
             * a float step value
-            * a channel name who's timestamps will be used as raster (starting with asammdf 5.5.0)
+            * a channel name whose timestamps will be used as raster (starting with asammdf 5.5.0)
             * an array (starting with asammdf 5.5.0)
 
         version : str
@@ -3026,7 +3023,7 @@ class MDF:
             in this case the original file version is used
 
         time_from_zero : bool
-            start time stamps from 0s in the cut measurement
+            start timestamps from 0s in the resampled measurement
 
         Returns
         -------
@@ -3262,10 +3259,10 @@ class MDF:
         record_count: int | None = None,
         validate: bool = False,
     ) -> list[Signal]:
-        """retrieve the channels listed in *channels* argument as *Signal*
-        objects
+        """Retrieve the channels listed in the *channels* argument as *Signal*
+        objects.
 
-        .. note:: the *dataframe* argument was removed in version 5.8.0
+        .. note:: the *dataframe* argument was removed in version 5.8.0,
                   use the ``to_dataframe`` method instead
 
         Parameters
@@ -3294,7 +3291,7 @@ class MDF:
             use a shared array for channels of the same channel group; default *True*
         ignore_value2text_conversions (False) : bool
             valid only for the channels that have value to text conversions and
-            if *raw=False*. If this is True then the raw numeric values will be
+            if *raw=False*. If this is *True* then the raw numeric values will be
             used, and the conversion will not be applied.
 
             .. versionchanged:: 5.8.0
@@ -3561,10 +3558,10 @@ class MDF:
         record_count: int | None = None,
         validate: bool = False,
     ) -> list[Signal]:
-        """retrieve the channels listed in *channels* argument as *Signal*
-        objects
+        """Retrieve the channels listed in the *channels* argument as *Signal*
+        objects.
 
-        .. note:: the *dataframe* argument was removed in version 5.8.0
+        .. note:: the *dataframe* argument was removed in version 5.8.0,
                   use the ``to_dataframe`` method instead
 
         Parameters
@@ -3593,7 +3590,7 @@ class MDF:
             use a shared array for channels of the same channel group; default *True*
         ignore_value2text_conversions (False) : bool
             valid only for the channels that have value to text conversions and
-            if *raw=False*. If this is True then the raw numeric values will be
+            if *raw=False*. If this is *True* then the raw numeric values will be
             used, and the conversion will not be applied.
 
             .. versionchanged:: 5.8.0
@@ -3771,21 +3768,21 @@ class MDF:
 
     @staticmethod
     def scramble(name: StrPathType, skip_attachments: bool = False, progress=None, **kwargs) -> Path:
-        """scramble text blocks and keep original file structure
+        """Scramble text blocks and keep original file structure.
 
         Parameters
         ----------
         name : str | pathlib.Path
             file name
         skip_attachments : bool
-            skip scrambling of attachments data if True
+            skip scrambling of attachments data if *True*
 
             .. versionadded:: 5.9.0
 
         Returns
         -------
         name : pathlib.Path
-            scrambled file name
+            name of scrambled file
 
         """
 
@@ -4075,7 +4072,7 @@ class MDF:
 
     @staticmethod
     def _fallback_scramble_mf4(name: StrOrBytesPathType) -> dict[int, bytes]:
-        """scramble text blocks and keep original file structure
+        """Scramble text blocks and keep original file structure.
 
         Parameters
         ----------
@@ -4085,7 +4082,7 @@ class MDF:
         Returns
         -------
         name : pathlib.Path
-            scrambled file name
+            name of scrambled file
 
         """
 
@@ -4127,9 +4124,9 @@ class MDF:
         ignore_value2text_conversions: bool = False,
         only_basenames: bool = False,
     ) -> pd.DataFrame:
-        """get channel group as pandas DataFrames. If there are multiple
+        """Get channel group as pandas DataFrames. If there are multiple
         occurrences for the same channel name, then a counter will be used to
-        make the names unique (<original_name>_<counter>)
+        make the names unique (<original_name>_<counter>).
 
         Parameters
         ----------
@@ -4139,7 +4136,7 @@ class MDF:
             use display name instead of standard channel name, if available.
         reduce_memory_usage : bool
             reduce memory usage by converting all float columns to float32 and
-            searching for minimum dtype that can reprezent the values found
+            searching for minimum dtype that can represent the values found
             in integer columns; default *False*
         raw : bool | dict[str, bool]
             the DataFrame will contain the raw channel values; default *False*
@@ -4154,7 +4151,7 @@ class MDF:
 
         ignore_value2text_conversions (False) : bool
             valid only for the channels that have value to text conversions and
-            if *raw=False*. If this is True then the raw numeric values will be
+            if *raw=False*. If this is *True* then the raw numeric values will be
             used, and the conversion will not be applied.
 
             .. versionadded:: 5.8.0
@@ -4186,7 +4183,7 @@ class MDF:
             new raster that can be
 
             * a float step value
-            * a channel name who's timestamps will be used as raster (starting with asammdf 5.5.0)
+            * a channel name whose timestamps will be used as raster (starting with asammdf 5.5.0)
             * an array (starting with asammdf 5.5.0)
 
             see `resample` for examples of using this argument
@@ -4236,15 +4233,15 @@ class MDF:
         numeric_1D_only: bool = False,
         progress=None,
     ) -> Iterator[pd.DataFrame]:
-        """generator that yields pandas DataFrame's that should not exceed
-        200MB of RAM
+        """Generator that yields pandas DataFrames that should not exceed
+        200MB of RAM.
 
         .. versionadded:: 5.15.0
 
         Parameters
         ----------
         channels : list
-            list of items to be filtered (default None); each item can be :
+            list of items to be filtered (default *None*); each item can be :
 
                 * a channel name string
                 * (channel name, group index, channel index) list or tuple
@@ -4255,7 +4252,7 @@ class MDF:
             new raster that can be
 
             * a float step value
-            * a channel name who's timestamps will be used as raster (starting with asammdf 5.5.0)
+            * a channel name whose timestamps will be used as raster (starting with asammdf 5.5.0)
             * an array (starting with asammdf 5.5.0)
 
             see `resample` for examples of using this argument
@@ -4273,12 +4270,12 @@ class MDF:
             only the component channels are saved, and their names will be
             prefixed with the parent channel.
         time_as_date : bool
-            the dataframe index will contain the datetime timestamps
+            the DataFrame index will contain the datetime timestamps
             according to the measurement start time; default *False*. If
             *True* then the argument ``time_from_zero`` will be ignored.
         reduce_memory_usage : bool
             reduce memory usage by converting all float columns to float32 and
-            searching for minimum dtype that can reprezent the values found
+            searching for minimum dtype that can represent the values found
             in integer columns; default *False*
         raw : bool | dict[str, bool]
             the columns will contain the raw values; default *False*
@@ -4291,31 +4288,31 @@ class MDF:
 
         ignore_value2text_conversions (False) : bool
             valid only for the channels that have value to text conversions and
-            if *raw=False*. If this is True then the raw numeric values will be
+            if *raw=False*. If this is *True* then the raw numeric values will be
             used, and the conversion will not be applied.
         use_interpolation (True) : bool
-            option to perform interpolations when multiple timestamp raster are
-            present. If *False* then dataframe columns will be automatically
-            filled with NaN's were the dataframe index values are not found in
+            option to perform interpolations when multiple timestamp rasters are
+            present. If *False* then DataFrame columns will be automatically
+            filled with NaNs were the DataFrame index values are not found in
             the current column's timestamps
         only_basenames (False) : bool
-            use jsut the field names, without prefix, for structures and channel
+            use just the field names, without prefix, for structures and channel
             arrays
         interpolate_outwards_with_nan : bool
             use NaN values for the samples that lie outside of the original
             signal's timestamps
         chunk_ram_size : int
-            desired data frame RAM usage in bytes; default 200 MB
+            desired DataFrame RAM usage in bytes; default 200 MB
         numeric_1D_only (False) : bool
             only keep the 1D-columns that have numeric values
 
             .. versionadded:: 7.0.0
 
 
-        Returns
-        -------
+        Yields
+        ------
         dataframe : pandas.DataFrame
-            yields pandas DataFrame's that should not exceed 200MB of RAM
+            pandas DataFrames that should not exceed 200MB of RAM
 
         """
 
@@ -4649,12 +4646,12 @@ class MDF:
         progress=None,
         use_polars=False,
     ) -> pd.DataFrame:
-        """generate pandas DataFrame
+        """Generate pandas DataFrame.
 
         Parameters
         ----------
         channels : list
-            list of items to be filtered (default None); each item can be :
+            list of items to be filtered (default *None*); each item can be :
 
                 * a channel name string
                 * (channel name, group index, channel index) list or tuple
@@ -4665,7 +4662,7 @@ class MDF:
             new raster that can be
 
             * a float step value
-            * a channel name who's timestamps will be used as raster (starting with asammdf 5.5.0)
+            * a channel name whose timestamps will be used as raster (starting with asammdf 5.5.0)
             * an array (starting with asammdf 5.5.0)
 
             see `resample` for examples of using this argument
@@ -4683,12 +4680,12 @@ class MDF:
             only the component channels are saved, and their names will be
             prefixed with the parent channel.
         time_as_date : bool
-            the dataframe index will contain the datetime timestamps
+            the DataFrame index will contain the datetime timestamps
             according to the measurement start time; default *False*. If
             *True* then the argument ``time_from_zero`` will be ignored.
         reduce_memory_usage : bool
             reduce memory usage by converting all float columns to float32 and
-            searching for minimum dtype that can reprezent the values found
+            searching for minimum dtype that can represent the values found
             in integer columns; default *False*
         raw : bool | dict[str, bool]
             the columns will contain the raw values; default *False*
@@ -4703,15 +4700,15 @@ class MDF:
 
         ignore_value2text_conversions (False) : bool
             valid only for the channels that have value to text conversions and
-            if *raw=False*. If this is True then the raw numeric values will be
+            if *raw=False*. If this is *True* then the raw numeric values will be
             used, and the conversion will not be applied.
 
             .. versionadded:: 5.8.0
 
         use_interpolation (True) : bool
-            option to perform interpolations when multiple timestamp raster are
-            present. If *False* then dataframe columns will be automatically
-            filled with NaN's were the dataframe index values are not found in
+            option to perform interpolations when multiple timestamp rasters are
+            present. If *False* then DataFrame columns will be automatically
+            filled with NaNs were the DataFrame index values are not found in
             the current column's timestamps
 
             .. versionadded:: 5.11.0
@@ -5060,7 +5057,7 @@ class MDF:
         prefix: str = "",
         progress=None,
     ) -> MDF:
-        """extract all possible CAN signal using the provided databases.
+        """Extract all possible CAN signals using the provided databases.
 
         Changed in version 6.0.0 from `extract_can_logging`
 
@@ -5069,13 +5066,13 @@ class MDF:
         database_files : dict
             each key will contain an iterable of database files for that bus type. The
             supported bus types are "CAN", "LIN". The iterables will contain the
-            (databases, valid bus) pairs. The database can be a  str, pathlib.Path or canamtrix.CanMatrix object.
+            (databases, valid bus) pairs. The database can be a str, pathlib.Path or canmatrix.CanMatrix object.
             The valid bus is an integer specifying for which bus channel the database
             can be applied; 0 means any bus channel.
 
             .. versionchanged:: 6.0.0 added canmatrix.CanMatrix type
 
-            .. versionchanged:: 6.3.0 added bus channel fileter
+            .. versionchanged:: 6.3.0 added bus channel filter
 
         version (None) : str
             output file version
@@ -5111,7 +5108,7 @@ class MDF:
         Returns
         -------
         mdf : MDF
-            new MDF file that contains the succesfully extracted signals
+            new *MDF* file that contains the succesfully extracted signals
 
         Examples
         --------
@@ -5797,7 +5794,7 @@ class MDF:
 
     @property
     def start_time(self) -> datetime:
-        """getter and setter the measurement start timestamp
+        """Getter and setter of the measurement start timestamp.
 
         Returns
         -------
@@ -5821,7 +5818,7 @@ class MDF:
         version: str | None = None,
         progress=None,
     ) -> MDF:
-        """convert *MDF* to other version
+        """Convert *MDF* to other version.
 
         .. versionadded:: 5.22.0
 
@@ -5935,18 +5932,18 @@ class MDF:
         source_path: str | None = None,
         acq_name: str | None = None,
     ) -> tuple[tuple[int, int], ...]:
-        """get occurrences of channel name in the file
+        """Get occurrences of channel name in the file.
 
         Parameters
         ----------
         channel : str
             channel name string
         source_name : str, optional
-            filter occurrences on source name, by default None
+            filter occurrences on source name, default *None*
         source_path : str, optional
-            filter occurrences on source path, by default None
+            filter occurrences on source path, default *None*
         acq_name : str, optional
-            filter occurrences on channel group acquisition name, by default None
+            filter occurrences on channel group acquisition name, default *None*
 
             .. versionadded:: 6.0.0
 
@@ -5979,7 +5976,7 @@ class MDF:
         mode: Literal["plain", "regex", "wildcard"] | SearchMode = SearchMode.plain,
         case_insensitive: bool = False,
     ) -> list[str]:
-        """search channels
+        """Search channels.
 
         .. versionadded:: 7.0.0
 
@@ -5994,7 +5991,7 @@ class MDF:
                 * `regex` : regular expression based search
                 * `wildcard` : wildcard based search
         case_insensitive : bool, optional
-            case sensitivity for the channel name search, by default False
+            case sensitivity for the channel name search, default *False*
 
         Returns
         -------

--- a/src/asammdf/signal.py
+++ b/src/asammdf/signal.py
@@ -34,8 +34,7 @@ logger = logging.getLogger("asammdf")
 
 
 class Signal:
-    """
-    The *Signal* represents a channel described by it's samples and timestamps.
+    """The *Signal* represents a channel described by its samples and timestamps.
     It can perform arithmetic operations against other *Signal* or numeric types.
     The operations are computed in respect to the timestamps (time correct).
     The non-float signals are not interpolated, instead the last value relative
@@ -53,16 +52,16 @@ class Signal:
     name : str
         signal name
     conversion : dict | channel conversion block
-        dict that contains extra conversion information about the signal ,
+        dict that contains extra conversion information about the signal;
         default *None*
     comment : str
-        signal comment, default ''
+        signal comment; default ''
     raw : bool
         signal samples are raw values, with no physical conversion applied
     master_metadata : list
         master name and sync type
     display_names : dict
-        display names used by mdf version 3
+        display names used by MDF version 3
     attachment : bytes, name
         channel attachment and name from MDF version 4
     source : Source
@@ -70,7 +69,7 @@ class Signal:
     bit_count : int
         bit count; useful for integer channels
     invalidation_bits : numpy.array | None
-        channel invalidation bits, default *None*
+        channel invalidation bits; default *None*
     encoding : str | None
         encoding for string signals; default *None*
     flags : Signal.Flags
@@ -223,8 +222,8 @@ class Signal:
 """
 
     def plot(self, validate: bool = True, index_only: bool = False) -> None:
-        """plot Signal samples. Pyqtgraph is used if it is available; in this
-        case see the GUI plot documentation to see the available commands
+        """Plot Signal samples. Pyqtgraph is used if it is available; in this
+        case see the GUI plot documentation to see the available commands.
 
         Parameters
         ----------
@@ -439,8 +438,7 @@ class Signal:
             FloatInterpolationModeType | FloatInterpolation
         ) = FloatInterpolation.LINEAR_INTERPOLATION,
     ) -> Signal:
-        """
-        Cuts the signal according to the *start* and *stop* values, by using
+        """Cut the signal according to the *start* and *stop* values, by using
         the insertion indexes in the signal's *time* axis.
 
         Parameters
@@ -840,7 +838,7 @@ class Signal:
         return result
 
     def extend(self, other: Signal) -> Signal:
-        """extend signal with samples from another signal
+        """Extend Signal with samples from another Signal.
 
         Parameters
         ----------
@@ -916,7 +914,7 @@ class Signal:
             FloatInterpolationModeType | FloatInterpolation
         ) = FloatInterpolation.LINEAR_INTERPOLATION,
     ) -> Signal:
-        """returns a new *Signal* interpolated using the *new_timestamps*
+        """Returns a new *Signal* interpolated using the *new_timestamps*.
 
         Parameters
         ----------
@@ -1369,7 +1367,7 @@ class Signal:
         self.samples[idx] = val
 
     def astype(self, np_type: DTypeLike) -> Signal:
-        """returns new *Signal* with samples of dtype *np_type*
+        """Returns new *Signal* with samples of dtype *np_type*.
 
         Parameters
         ----------
@@ -1401,8 +1399,7 @@ class Signal:
         )
 
     def physical(self, copy: bool = True) -> Signal:
-        """
-        get the physical samples values
+        """Get the physical samples values.
 
         Parameters
         ----------
@@ -1452,7 +1449,7 @@ class Signal:
         )
 
     def validate(self, copy: bool = True) -> Signal:
-        """apply invalidation bits if they are available for this signal
+        """Apply invalidation bits if they are available for this signal.
 
         Parameters
         ----------
@@ -1498,7 +1495,7 @@ class Signal:
         return signal
 
     def copy(self) -> Signal:
-        """copy all attributes to a new Signal"""
+        """Copy all attributes to a new Signal."""
         return Signal(
             self.samples.copy(),
             self.timestamps.copy(),

--- a/src/asammdf/signal.py
+++ b/src/asammdf/signal.py
@@ -480,10 +480,20 @@ class Signal:
 
         Examples
         --------
+        >>> from asammdf import Signal
+        >>> import numpy as np
+        >>> old_sig = Signal(np.arange(0.03, 100, 0.05), np.arange(0.03, 100, 0.05), name='SIG')
         >>> new_sig = old_sig.cut(1.0, 10.5)
         >>> new_sig.timestamps[0], new_sig.timestamps[-1]
-        0.98, 10.48
+        (1.0, 10.5)
 
+        >>> new_sig = old_sig.cut(1.0, 10.5, include_ends=False)
+        >>> new_sig.timestamps[0], new_sig.timestamps[-1]
+        (1.03, 10.48)
+
+        >>> new_sig = old_sig.cut(1.0, 10.5, float_interpolation_mode=0)
+        >>> new_sig.samples[0], new_sig.samples[-1]
+        (0.98, 10.48)
         """
 
         integer_interpolation_mode = IntegerInterpolation(integer_interpolation_mode)

--- a/src/asammdf/signal.py
+++ b/src/asammdf/signal.py
@@ -451,7 +451,7 @@ class Signal:
             stop timestamp for cutting
         include_ends : bool
             include the *start* and *stop* timestamps after cutting the signal.
-            If *start* and *stop* are found in the original timestamps, then
+            If *start* and *stop* are not found in the original timestamps, then
             the new samples will be computed using interpolation. Default *True*
 
         integer_interpolation_mode : int


### PR DESCRIPTION
This PR contains only docstring changes, except a minor fix in CONTRIBUTING.md. The changes are mostly stylistic, for example capitalization, punctuation, italicization, fixing typos and indentation. I think this package deserves proper-looking docstrings :)

Some code examples have been fixed, many relating to `MdfException: Multiple occurrences ...`. There are also a few minor corrections, most notably a missing "not" in the decription of the `include_ends` argument.

I have not gone through all files but rather focused on the MDF and Signal objects and their methods, whose docstrings I assume are the ones most frequently read.
