### PR TITLE
Format with ruff instead of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,4 @@
 repos:
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.1.0
-    hooks:
-      - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.5
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.5
+    rev: v0.9.6
     hooks:
       - id: ruff
         args: [--fix]
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,6 @@ Otherwise, you can just push and the tests will be run by GitHub Actions.
 
 ## Style guide
 
-Just run [_black_](https://black.readthedocs.io) on modified files before sending the PR. There is no need to reinvent the wheel here!
+Just run [`ruff format`](https://docs.astral.sh/ruff/formatter/) on modified files before sending the PR. There is no need to reinvent the wheel here!
 
 **Tip**: install Git hooks using pre-commit `pre-commit install --install-hooks`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Clone the repository with submodules, make sure you have a C compiler installed,
 ```bash
 python -m venv .venv  # create virtual environment in .venv
 source .venv/bin/activate  # activate virtual environment (POSIX)
-.venv/Scripts/activate.bat  # activate virtual environment (Windows)
+.venv\Scripts\activate.bat  # activate virtual environment (Windows)
 pip install --requirement requirements.txt  # install development dependencies (includes asammdf in editable mode)
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ _asammdf_ works on Python >= 3.9
 ![PyPI - License](https://img.shields.io/pypi/l/asammdf)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/asammdf)
 ![PyPI - Version](https://img.shields.io/pypi/v/asammdf)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 

--- a/bdist_wheel.bat
+++ b/bdist_wheel.bat
@@ -1,2 +1,2 @@
-run_black_and_ruff.bat && ^
+run_ruff.bat && ^
 python -m build --wheel

--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -817,8 +817,8 @@ def main(text_output, fmt):
     output.append(f"* numpy {np.__version__}")
     output.append(f"* {installed_ram}GB installed RAM\n")
     output.append("Notations used in the results\n")
-    output.append("* compress = mdfreader mdf object created with " "compression=blosc")
-    output.append("* nodata = mdfreader mdf object read with " "no_data_loading=True")
+    output.append("* compress = mdfreader mdf object created with compression=blosc")
+    output.append("* nodata = mdfreader mdf object read with no_data_loading=True")
     output.append("\nFiles used for benchmark:\n")
     output.append(f"* mdf version {v3_version}")
     output.append(f"    * {v3_size} MB file size")
@@ -1006,7 +1006,7 @@ def _cmd_line_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--path",
-        help=("path to test files, " "if not provided the script folder is used"),
+        help=("path to test files, if not provided the script folder is used"),
     )
     parser.add_argument(
         "--text_output",

--- a/ci/support.py
+++ b/ci/support.py
@@ -50,7 +50,7 @@ class ReportTests:
             verdict_details = ""
             for data in datas:
                 verdict_table_entry = (
-                    f"|{data.classname}|[{data.name}](#user-content-{data.name.lower()})|" f"{data.time}|\n"
+                    f"|{data.classname}|[{data.name}](#user-content-{data.name.lower()})|{data.time}|\n"
                 )
                 verdict_data_entry = (
                     f"<details><summary>\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,17 +69,6 @@ metadata.version.input = "src/asammdf/version.py"
 wheel.packages = ["src/asammdf"]
 wheel.py-api = "cp39"
 
-[tool.black]
-line-length = 120
-required-version = "25"
-target-version = ['py39']
-force-exclude = '''
-(
-    ^/ext |
-    ^/src/asammdf/gui/ui |
-)
-'''
-
 [tool.coverage]
 run.relative_files = true
 run.source_pkgs = ["asammdf"]
@@ -144,6 +133,7 @@ module = [
 ignore_errors = true
 
 [tool.ruff]
+line-length = 120
 target-version = "py39"
 extend-exclude = ["./src/asammdf/gui/ui", "./ext"]
 force-exclude = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@
 --requirement doc/requirements.txt
 --requirement test/requirements.txt
 --requirement types-requirements.txt
-black~=25.1  # Aligned with .pre-commit-config.yaml
 build
 mypy~=1.14
 pre-commit

--- a/run_black_and_ruff.bat
+++ b/run_black_and_ruff.bat
@@ -1,3 +1,0 @@
-pip install --upgrade black~=25.1 ruff~=0.9.0 && ^
-black --config pyproject.toml . asammdf.spec && ^
-ruff check --fix

--- a/run_ruff.bat
+++ b/run_ruff.bat
@@ -1,0 +1,3 @@
+pip install --upgrade ruff~=0.9.0 && ^
+ruff check --fix && ^
+ruff format

--- a/src/asammdf/blocks/bus_logging_utils.py
+++ b/src/asammdf/blocks/bus_logging_utils.py
@@ -37,7 +37,6 @@ def defined_j1939_bit_count(signal):
 
 
 def apply_conversion(vals: NDArray[Any], signal: Signal, ignore_value2text_conversion: bool) -> NDArray[Any]:
-
     conv = get_conversion(signal)
     if conv and not (ignore_value2text_conversion and conv.conversion_type in v4c.CONVERSIONS_WITH_TEXTS):
         vals = conv.convert(vals)
@@ -464,7 +463,6 @@ def get_conversion(signal: Signal) -> v4b.ChannelConversion | None:
         conv["default"] = from_dict({"a": a, "b": b})
 
     elif signal.values:
-
         for i, (val, text) in enumerate(signal.values.items()):
             conv[f"upper_{i}"] = val
             conv[f"lower_{i}"] = val

--- a/src/asammdf/blocks/conversion_utils.py
+++ b/src/asammdf/blocks/conversion_utils.py
@@ -279,7 +279,6 @@ def conversion_transfer(
 
 
 def inverse_conversion(conversion: Optional[Union[ChannelConversionType, dict]]) -> Optional[v4b.ChannelConversion]:
-
     if isinstance(conversion, v3b.ChannelConversion):
         conversion = conversion_transfer(conversion, version=4)
 
@@ -314,7 +313,6 @@ def inverse_conversion(conversion: Optional[Union[ChannelConversionType, dict]])
                     conv = v4b.ChannelConversion(**conv)
 
             elif a == 0 and d == 0:
-
                 if e == 0 and b == 0:
                     conv = None
                 else:

--- a/src/asammdf/blocks/mdf_common.py
+++ b/src/asammdf/blocks/mdf_common.py
@@ -201,7 +201,7 @@ class MDF_Common(ABC, Generic[_Group]):
 
         if name is None:
             if group is None or index is None:
-                message = "Invalid arguments for channel selection: " 'must give "name" or, "group" and "index"'
+                message = 'Invalid arguments for channel selection: must give "name" or, "group" and "index"'
                 raise MdfException(message)
             else:
                 gp_nr, ch_nr = group, index

--- a/src/asammdf/blocks/mdf_common.py
+++ b/src/asammdf/blocks/mdf_common.py
@@ -17,7 +17,7 @@ __all__ = ["MDF_Common"]
 
 
 class MDF_Common:
-    """common methods for MDF objects"""
+    """Common methods for MDF objects."""
 
     def _set_temporary_master(self, master: NDArray[Any] | None) -> None:
         self._master = master
@@ -30,19 +30,20 @@ class MDF_Common:
         index: int | None = None,
     ) -> tuple[int, int]:
         """Gets channel comment.
+
         Channel can be specified in two ways:
 
         * using the first positional argument *name*
 
             * if there are multiple occurrences for this channel then the
-            *group* and *index* arguments can be used to select a specific
-            group.
+              *group* and *index* arguments can be used to select a specific
+              group.
             * if there are multiple occurrences for this channel and either the
-            *group* or *index* arguments is None then a warning is issued
+              *group* or *index* arguments is None then a warning is issued
 
         * using the group number (keyword argument *group*) and the channel
-        number (keyword argument *index*). Use *info* method for group and
-        channel numbers
+          number (keyword argument *index*). Use *info* method for group and
+          channel numbers
 
 
         Parameters

--- a/src/asammdf/blocks/mdf_v3.py
+++ b/src/asammdf/blocks/mdf_v3.py
@@ -116,15 +116,14 @@ class MDF3(MDF_Common):
     * ``channel_dependencies`` - list of *ChannelArrayBlock* in case of channel
       arrays; list of Channel objects in case of structure channel
       composition
-    * ``data_block`` - address of
-      data block
+    * ``data_block`` - address of data block
     * ``data_location``- integer code for data location (original file,
       temporary file or memory)
     * ``data_block_addr`` - list of raw samples starting addresses
     * ``data_block_type`` - list of codes for data block type
     * ``data_block_size`` - list of raw samples block size
     * ``sorted`` - sorted indicator flag
-    * ``record_size`` - dict that maps record ID's to record sizes in bytes
+    * ``record_size`` - dict that maps record IDs to record sizes in bytes
     * ``size`` - total size of data block for the current group
     * ``trigger`` - *Trigger* object for current group
 
@@ -163,7 +162,7 @@ class MDF3(MDF_Common):
 
     masters_db : dict
         used for fast master channel access; for each group index key the value
-         is the master channel index
+        is the master channel index
     memory : str
         memory optimization option
     name : string
@@ -974,7 +973,7 @@ class MDF3(MDF_Common):
         post_time: float = 0,
         comment: str = "",
     ) -> None:
-        """add trigger to data group
+        """Add trigger to data group.
 
         Parameters
         ----------
@@ -2086,9 +2085,7 @@ class MDF3(MDF_Common):
         comment: str = "",
         units: dict[str, str | bytes] | None = None,
     ) -> None:
-        """
-        Appends a new data group from a Pandas data frame.
-        """
+        """Appends a new data group from a Pandas DataFrame."""
         units = units or {}
 
         t = df.index
@@ -2335,9 +2332,9 @@ class MDF3(MDF_Common):
         gp.trigger = None
 
     def close(self) -> None:
-        """if the MDF was created with memory='minimum' and new
+        """If the MDF was created with memory='minimum' and new
         channels have been appended, then this must be called just before the
-        object is not used anymore to clean-up the temporary file
+        object is not used anymore to clean-up the temporary file.
 
         """
         try:
@@ -2386,8 +2383,7 @@ class MDF3(MDF_Common):
             print(format_exc())
 
     def extend(self, index: int, signals: list[tuple[NDArray[Any], None]]) -> None:
-        """
-        Extend a group with new samples. *signals* contains (values, invalidation_bits)
+        """Extend a group with new samples. *signals* contains (values, invalidation_bits)
         pairs for each extended signal. Since MDF3 does not support invalidation
         bits, the second item of each pair must be None. The first pair is the master channel's pair, and the
         next pairs must respect the same order in which the signals were appended. The samples must have raw
@@ -2671,6 +2667,7 @@ class MDF3(MDF_Common):
         index: int | None = None,
     ) -> str:
         """Gets channel comment.
+
         Channel can be specified in two ways:
 
         * using the first positional argument *name*
@@ -2763,6 +2760,7 @@ class MDF3(MDF_Common):
         skip_channel_validation: bool = False,
     ) -> Signal | tuple[NDArray[Any], None]:
         """Gets channel samples.
+
         Channel can be specified in two ways:
 
         * using the first positional argument *name*
@@ -2805,7 +2803,7 @@ class MDF3(MDF_Common):
             if *data=None* use this to select the record offset from which the
             group data should be loaded
         skip_channel_validation (False) : bool
-            skip validation of channel name, group index and channel index; defualt
+            skip validation of channel name, group index and channel index; default
             *False*. If *True*, the caller has to make sure that the *group* and *index*
             arguments are provided and are correct.
 
@@ -3158,16 +3156,16 @@ class MDF3(MDF_Common):
         record_count: int | None = None,
         one_piece: bool = False,
     ) -> NDArray[Any]:
-        """returns master channel samples for given group
+        """Returns master channel samples for given group.
 
         Parameters
         ----------
         index : int
             group index
         data : (bytes, int)
-            (data block raw bytes, fragment offset); default None
+            (data block raw bytes, fragment offset); default *None*
         raster : float
-            raster to be used for interpolation; default None
+            raster to be used for interpolation; default *None*
 
             .. deprecated:: 5.13.0
 
@@ -3313,10 +3311,10 @@ class MDF3(MDF_Common):
         return timestamps
 
     def iter_get_triggers(self) -> Iterator[TriggerInfoDict]:
-        """generator that yields triggers
+        """Generator that yields triggers.
 
-        Returns
-        -------
+        Yields
+        ------
         trigger_info : dict
             trigger information with the following keys:
 
@@ -3342,7 +3340,7 @@ class MDF3(MDF_Common):
                     yield trigger_info
 
     def info(self) -> dict[str, Any]:
-        """get MDF information as a dict
+        """Get MDF information as a dict.
 
         Examples
         --------
@@ -3378,7 +3376,7 @@ class MDF3(MDF_Common):
 
     @property
     def start_time(self) -> datetime:
-        """getter and setter the measurement start timestamp
+        """Getter and setter of the measurement start timestamp.
 
         Returns
         -------

--- a/src/asammdf/blocks/mdf_v3.py
+++ b/src/asammdf/blocks/mdf_v3.py
@@ -3198,7 +3198,7 @@ class MDF3(MDF_Common[Group]):
 
         if raster is not None:
             raise PendingDeprecationWarning(
-                "the argument raster is deprecated since version 5.13.0 " "and will be removed in a future release"
+                "the argument raster is deprecated since version 5.13.0 and will be removed in a future release"
             )
 
         fragment = data
@@ -3454,7 +3454,7 @@ class MDF3(MDF_Common[Group]):
                     else:
                         cntr += 1
                 message = (
-                    f'Destination file "{dst}" already exists ' f'and "overwrite" is False. Saving MDF file as "{name}"'
+                    f'Destination file "{dst}" already exists and "overwrite" is False. Saving MDF file as "{name}"'
                 )
                 logger.warning(message)
                 dst = name

--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -8854,9 +8854,8 @@ class MDF4(MDF_Common):
         raw: bool = False,
         ignore_value2text_conversion: bool = True,
     ) -> Signal:
-        """get CAN message signal. You can specify an external CAN database (
-        *database* argument) or canmatrix database object that has already been
-        loaded from a file (*db* argument).
+        """Get CAN message signal. You can specify an external CAN database path
+        or a canmatrix database object that has already been loaded from a file.
 
         The signal name can be specified in the following ways
 
@@ -9127,9 +9126,8 @@ class MDF4(MDF_Common):
         raw: bool = False,
         ignore_value2text_conversion: bool = True,
     ) -> Signal:
-        """get LIN message signal. You can specify an external LIN database (
-        *database* argument) or canmatrix database object that has already been
-        loaded from a file (*db* argument).
+        """Get LIN message signal. You can specify an external LIN database path
+        or a canmatrix database object that has already been loaded from a file.
 
         The signal name can be specified in the following ways
 

--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -194,13 +194,13 @@ class MDF4(MDF_Common):
     * ``channel_dependencies`` - list of *ChannelArrayBlock* in case of channel arrays;
       list of Channel objects in case of structure channel composition
     * ``data_block`` - address of data block
-    * ``data_location``- integer code for data location (original file, temporary file or
+    * ``data_location`` - integer code for data location (original file, temporary file or
       memory)
     * ``data_block_addr`` - list of raw samples starting addresses
     * ``data_block_type`` - list of codes for data block type
     * ``data_block_size`` - list of raw samples block size
     * ``sorted`` - sorted indicator flag
-    * ``record_size`` - dict that maps record ID's to record sizes in bytes (including invalidation bytes)
+    * ``record_size`` - dict that maps record IDs to record sizes in bytes (including invalidation bytes)
     * ``param`` - row size used for transposition, in case of transposed zipped blocks
 
 
@@ -2638,7 +2638,7 @@ class MDF4(MDF_Common):
         pos_invalidation_bit: int,
         fragment: tuple[bytes, int, int, ReadableBufferType | None],
     ) -> NDArray[bool_]:
-        """get invalidation indexes for the channel
+        """Get invalidation indexes for the channel.
 
         Parameters
         ----------
@@ -2699,8 +2699,7 @@ class MDF4(MDF_Common):
         common_timebase: bool = False,
         units: dict[str, str | bytes] | None = None,
     ) -> int | None:
-        """
-        Appends a new data group.
+        """Appends a new data group.
 
         For channel dependencies type Signals, the *samples* attribute must be
         a numpy.recarray
@@ -4722,10 +4721,7 @@ class MDF4(MDF_Common):
         comment: str | None = None,
         units: dict[str, str | bytes] | None = None,
     ) -> None:
-        """
-        Appends a new data group from a Pandas data frame.
-
-        """
+        """Appends a new data group from a Pandas DataFrame."""
         units = units or {}
 
         if df.shape == (0, 0):
@@ -5869,8 +5865,7 @@ class MDF4(MDF_Common):
         return offset, dg_cntr, ch_cntr, struct_self, fields, types
 
     def extend(self, index: int, signals: list[tuple[NDArray[Any], NDArray[Any] | None]]) -> None:
-        """
-        Extend a group with new samples. *signals* contains (values, invalidation_bits)
+        """Extend a group with new samples. *signals* contains (values, invalidation_bits)
         pairs for each extended signal. The first pair is the master channel's pair, and the
         next pairs must respect the same order in which the signals were appended. The samples must have raw
         or physical values according to the *Signals* used for the initial append.
@@ -5880,7 +5875,7 @@ class MDF4(MDF_Common):
         index : int
             group index
         signals : list
-            list on (numpy.ndarray, numpy.ndarray) objects
+            list of (numpy.ndarray, numpy.ndarray) objects
 
         Examples
         --------
@@ -6158,8 +6153,7 @@ class MDF4(MDF_Common):
                     )
 
     def _extend_column_oriented(self, index: int, signals: list[tuple[NDArray[Any], NDArray[Any] | None]]) -> None:
-        """
-        Extend a group with new samples. *signals* contains (values, invalidation_bits)
+        """Extend a group with new samples. *signals* contains (values, invalidation_bits)
         pairs for each extended signal. The first pair is the master channel's pair, and the
         next pairs must respect the same order in which the signals were appended. The samples must have raw
         or physical values according to the *Signals* used for the initial append.
@@ -6169,7 +6163,7 @@ class MDF4(MDF_Common):
         index : int
             group index
         signals : list
-            list on (numpy.ndarray, numpy.ndarray) objects
+            list of (numpy.ndarray, numpy.ndarray) objects
 
         Examples
         --------
@@ -6311,7 +6305,7 @@ class MDF4(MDF_Common):
         embedded: bool = True,
         password: str | bytes | None = None,
     ) -> int:
-        """attach embedded attachment as application/octet-stream.
+        """Attach embedded attachment as application/octet-stream.
 
         Parameters
         ----------
@@ -6442,9 +6436,10 @@ class MDF4(MDF_Common):
         return index
 
     def close(self) -> None:
-        """if the MDF was created with memory=False and new
+        """If the MDF was created with memory=False and new
         channels have been appended, then this must be called just before the
-        object is not used anymore to clean-up the temporary file"""
+        object is not used anymore to clean-up the temporary file.
+        """
 
         if self._closed:
             return
@@ -6703,7 +6698,7 @@ class MDF4(MDF_Common):
             time raster in seconds
         samples_only : bool
             if *True* return only the channel samples as numpy array; if
-                *False* return a *Signal* object
+            *False* return a *Signal* object
         data : bytes
             prevent redundant data read by providing the raw data group samples
         raw : bool
@@ -6718,7 +6713,7 @@ class MDF4(MDF_Common):
             number of records to read; default *None* and in this case all
             available records are used
         skip_channel_validation (False) : bool
-            skip validation of channel name, group index and channel index; defualt
+            skip validation of channel name, group index and channel index; default
             *False*. If *True*, the caller has to make sure that the *group* and *index*
             arguments are provided and are correct.
 
@@ -8592,14 +8587,14 @@ class MDF4(MDF_Common):
         record_count: int | None = None,
         one_piece: bool = False,
     ) -> NDArray[Any]:
-        """returns master channel samples for given group
+        """Returns master channel samples for given group.
 
         Parameters
         ----------
         index : int
             group index
         data : (bytes, int, int, bytes|None)
-            (data block raw bytes, fragment offset, count, invalidation bytes); default None
+            (data block raw bytes, fragment offset, count, invalidation bytes); default *None*
 
         record_offset : int
             if *data=None* use this to select the record offset from which the
@@ -8791,9 +8786,9 @@ class MDF4(MDF_Common):
         raw: bool = False,
         ignore_value2text_conversion: bool = True,
     ) -> Signal:
-        """get a signal decoded from a raw bus logging. The currently supported buses are
+        """Get a signal decoded from a raw bus logging. The currently supported buses are
         CAN and LIN (LDF databases are not supported, they need to be converted to DBC and
-        feed to this function)
+        fed to this function).
 
         .. versionadded:: 6.0.0
 
@@ -8816,8 +8811,8 @@ class MDF4(MDF_Common):
             return channel samples without applying the conversion rule; default
             `False`
         ignore_value2text_conversion : bool
-            return channel samples without values that have a description in .dbc or .arxml file
-            `True`
+            return channel samples without values that have a description in .dbc or .arxml file;
+            default `True`
 
         Returns
         -------
@@ -8898,8 +8893,8 @@ class MDF4(MDF_Common):
             return channel samples without applying the conversion rule; default
             `False`
         ignore_value2text_conversion : bool
-            return channel samples without values that have a description in .dbc or .arxml file
-            `True`
+            return channel samples without values that have a description in .dbc or .arxml file;
+            default `True`
 
         Returns
         -------
@@ -9154,8 +9149,8 @@ class MDF4(MDF_Common):
             return channel samples without applying the conversion rule; default
             `False`
         ignore_value2text_conversion : bool
-            return channel samples without values that have a description in .dbc, .arxml or .ldf file
-            `True`
+            return channel samples without values that have a description in .dbc, .arxml or .ldf file;
+            default `True`
 
         Returns
         -------
@@ -9293,7 +9288,7 @@ class MDF4(MDF_Common):
         raise MdfException(f'No logging from "{signal}" was found in the measurement')
 
     def info(self) -> dict[str, Any]:
-        """get MDF information as a dict
+        """Get MDF information as a dict.
 
         Examples
         --------
@@ -9322,7 +9317,7 @@ class MDF4(MDF_Common):
 
     @property
     def start_time(self) -> datetime:
-        """getter and setter the measurement start timestamp
+        """Getter and setter of the measurement start timestamp.
 
         Returns
         -------
@@ -9348,12 +9343,12 @@ class MDF4(MDF_Common):
         """Save MDF to *dst*. If overwrite is *True* then the destination file
         is overwritten, otherwise the file name is appended with '.<cntr>', were
         '<cntr>' is the first counter that produces a new file name
-        (that does not already exist in the filesystem)
+        (that does not already exist in the filesystem).
 
         Parameters
         ----------
         dst : str
-            destination file name, Default ''
+            destination file name
         overwrite : bool
             overwrite flag, default *False*
         compression : int
@@ -9365,7 +9360,7 @@ class MDF4(MDF_Common):
               the smallest files)
 
         add_history_block : bool
-            option to add file historyu block
+            option to add file history block
 
         Returns
         -------

--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -423,7 +423,7 @@ class MDF4(MDF_Common[Group]):
         flags = self.identification["unfinalized_standard_flags"]
 
         if flags & 1:
-            message = f"Unfinalised file {self.name}:" " Update of cycle counters for CG/CA blocks required"
+            message = f"Unfinalised file {self.name}: Update of cycle counters for CG/CA blocks required"
 
             logger.info(message)
         if flags & 1 << 1:
@@ -440,17 +440,13 @@ class MDF4(MDF_Common[Group]):
             logger.info(message)
         if flags & 1 << 4:
             message = (
-                f"Unfinalised file {self.name}:"
-                " Update of last DL block in each chained list"
-                " of DL blocks required"
+                f"Unfinalised file {self.name}: Update of last DL block in each chained list of DL blocks required"
             )
 
             logger.info(message)
         if flags & 1 << 5:
             message = (
-                f"Unfinalised file {self.name}:"
-                " Update of cg_data_bytes and cg_inval_bytes"
-                " in VLSD CG block required"
+                f"Unfinalised file {self.name}: Update of cg_data_bytes and cg_inval_bytes in VLSD CG block required"
             )
 
             logger.info(message)
@@ -1304,7 +1300,6 @@ class MDF4(MDF_Common[Group]):
                     data = b"".join(data)
 
                 else:
-
                     data = bytearray()
 
                     start_offset = int(start_offset)
@@ -1719,7 +1714,7 @@ class MDF4(MDF_Common[Group]):
                         cur_invalidation_size += inv_size
 
                 if (vv := (perf_counter() - tt)) > 10:
-                    print(f"{ss / 1024/1024 / vv:.6f} MB/s {cc=} {vv=}")
+                    print(f"{ss / 1024 / 1024 / vv:.6f} MB/s {cc=} {vv=}")
                     cc = 0
                     ss = 0
                     tt = perf_counter()
@@ -5922,7 +5917,6 @@ class MDF4(MDF_Common[Group]):
 
             # first add the signals in the simple signal list
             if sig_type == v4c.SIGNAL_TYPE_SCALAR:
-
                 if not signal.flags["C_CONTIGUOUS"]:
                     signal = np.ascontiguousarray(signal)
 
@@ -5946,7 +5940,6 @@ class MDF4(MDF_Common[Group]):
                     fields.append((vals, sig_size))
 
             elif sig_type == v4c.SIGNAL_TYPE_STRUCTURE_COMPOSITION:
-
                 if not signal.flags["C_CONTIGUOUS"]:
                     signal = np.ascontiguousarray(signal)
 
@@ -7527,7 +7520,6 @@ class MDF4(MDF_Common[Group]):
         master_is_required: bool,
         skip_vlsd: bool = False,
     ) -> tuple[NDArray[Any], NDArray[Any] | None, NDArray[Any] | None, str | None]:
-
         grp = group
         # get group data
         if data is None:
@@ -8500,7 +8492,6 @@ class MDF4(MDF_Common[Group]):
 
                             signals.append((signal, invalidation_bits))
                 else:
-
                     if idx == 0:
                         for channel_index in channels:
                             signal = self.get(
@@ -8658,7 +8649,6 @@ class MDF4(MDF_Common[Group]):
             metadata = (time_name, time_ch.sync_type)
 
             if time_ch.channel_type == v4c.CHANNEL_TYPE_VIRTUAL_MASTER:
-
                 if record_count is None:
                     t = arange(record_offset, cycles_nr, 1, dtype=float64)
                 else:
@@ -9393,8 +9383,7 @@ class MDF4(MDF_Common[Group]):
                         else:
                             cntr += 1
                     message = (
-                        f'Destination file "{dst}" already exists '
-                        f'and "overwrite" is False. Saving MDF file as "{name}"'
+                        f'Destination file "{dst}" already exists and "overwrite" is False. Saving MDF file as "{name}"'
                     )
                     logger.warning(message)
                     dst = name
@@ -10838,9 +10827,7 @@ class MDF4(MDF_Common[Group]):
                     group=group_index,
                     data=fragment,
                     samples_only=True,
-                )[
-                    0
-                ].astype("<u1")
+                )[0].astype("<u1")
 
                 msg_ids = (
                     self.get(
@@ -10848,9 +10835,7 @@ class MDF4(MDF_Common[Group]):
                         group=group_index,
                         data=fragment,
                         samples_only=True,
-                    )[
-                        0
-                    ].astype("<u4")
+                    )[0].astype("<u4")
                     & 0x1FFFFFFF
                 )
 
@@ -10878,9 +10863,7 @@ class MDF4(MDF_Common[Group]):
                     group=group_index,
                     data=fragment,
                     samples_only=True,
-                )[
-                    0
-                ].astype("<u1")
+                )[0].astype("<u1")
 
                 msg_ids = (
                     self.get(
@@ -10888,9 +10871,7 @@ class MDF4(MDF_Common[Group]):
                         group=group_index,
                         data=fragment,
                         samples_only=True,
-                    )[
-                        0
-                    ].astype("<u4")
+                    )[0].astype("<u4")
                     & 0x1FFFFFFF
                 )
 
@@ -10941,9 +10922,7 @@ class MDF4(MDF_Common[Group]):
                     group=group_index,
                     data=fragment,
                     samples_only=True,
-                )[
-                    0
-                ].astype("<u1")
+                )[0].astype("<u1")
 
                 msg_ids = self.get("CAN_DataFrame.ID", group=group_index, data=fragment).astype("<u4") & 0x1FFFFFFF
 
@@ -11095,9 +11074,7 @@ class MDF4(MDF_Common[Group]):
                         group=group_index,
                         data=fragment,
                         samples_only=True,
-                    )[
-                        0
-                    ].astype("<u4")
+                    )[0].astype("<u4")
                     & 0x1FFFFFFF
                 )
 

--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -2727,31 +2727,30 @@ class MDF4(MDF_Common):
 
         Examples
         --------
+        >>> from asammdf import MDF, Signal
+        >>> import numpy as np
+
         >>> # case 1 conversion type None
         >>> s1 = np.array([1, 2, 3, 4, 5])
         >>> s2 = np.array([-1, -2, -3, -4, -5])
         >>> s3 = np.array([0.1, 0.04, 0.09, 0.16, 0.25])
         >>> t = np.array([0.001, 0.002, 0.003, 0.004, 0.005])
-        >>> names = ['Positive', 'Negative', 'Float']
-        >>> units = ['+', '-', '.f']
-        >>> info = {}
         >>> s1 = Signal(samples=s1, timestamps=t, unit='+', name='Positive')
         >>> s2 = Signal(samples=s2, timestamps=t, unit='-', name='Negative')
         >>> s3 = Signal(samples=s3, timestamps=t, unit='flts', name='Floats')
-        >>> mdf = MDF4('new.mdf')
-        >>> mdf.append([s1, s2, s3], comment='created by asammdf v4.0.0')
+        >>> mdf = MDF(version='4.10')
+        >>> mdf.append([s1, s2, s3], comment='created by asammdf')
+
         >>> # case 2: VTAB conversions from channels inside another file
-        >>> mdf1 = MDF4('in.mf4')
+        >>> mdf1 = MDF('in.mf4')
         >>> ch1 = mdf1.get("Channel1_VTAB")
         >>> ch2 = mdf1.get("Channel2_VTABR")
-        >>> sigs = [ch1, ch2]
-        >>> mdf2 = MDF4('out.mf4')
-        >>> mdf2.append(sigs, comment='created by asammdf v4.0.0')
+        >>> mdf2 = MDF('out.mf4')
+        >>> mdf2.append([ch1, ch2], comment='created by asammdf')
         >>> mdf2.append(ch1, comment='just a single channel')
         >>> df = pd.DataFrame.from_dict({'s1': np.array([1, 2, 3, 4, 5]), 's2': np.array([-1, -2, -3, -4, -5])})
         >>> units = {'s1': 'V', 's2': 'A'}
         >>> mdf2.append(df, units=units)
-
         """
         source_block = SourceInformation.from_common_source(acq_source) if acq_source else acq_source
 
@@ -5885,25 +5884,25 @@ class MDF4(MDF_Common):
 
         Examples
         --------
-        >>> # case 1 conversion type None
+        >>> from asammdf import MDF, Signal
+        >>> import numpy as np
         >>> s1 = np.array([1, 2, 3, 4, 5])
         >>> s2 = np.array([-1, -2, -3, -4, -5])
         >>> s3 = np.array([0.1, 0.04, 0.09, 0.16, 0.25])
         >>> t = np.array([0.001, 0.002, 0.003, 0.004, 0.005])
-        >>> names = ['Positive', 'Negative', 'Float']
-        >>> units = ['+', '-', '.f']
         >>> s1 = Signal(samples=s1, timestamps=t, unit='+', name='Positive')
         >>> s2 = Signal(samples=s2, timestamps=t, unit='-', name='Negative')
         >>> s3 = Signal(samples=s3, timestamps=t, unit='flts', name='Floats')
-        >>> mdf = MDF4('new.mdf')
-        >>> mdf.append([s1, s2, s3], comment='created by asammdf v1.1.0')
+        >>> mdf = MDF(version='4.10')
+        >>> mdf.append([s1, s2, s3], comment='created by asammdf')
         >>> t = np.array([0.006, 0.007, 0.008, 0.009, 0.010])
-        >>> # extend without invalidation bits
-        >>> mdf2.extend(0, [(t, None), (s1, None), (s2, None), (s3, None)])
-        >>> # some invaldiation btis
-        >>> s1_inv = np.array([0,0,0,1,1], dtype=np.bool)
-        >>> mdf2.extend(0, [(t, None), (s1.samples, None), (s2.samples, None), (s3.samples, None)])
 
+        >>> # extend without invalidation bits
+        >>> mdf.extend(0, [(t, None), (s1.samples, None), (s2.samples, None), (s3.samples, None)])
+
+        >>> # some invalidation bits
+        >>> s1_inv = np.array([0, 0, 0, 1, 1], dtype=np.bool)
+        >>> mdf.extend(0, [(t, None), (s1.samples, s1_inv), (s2.samples, None), (s3.samples, None)])
         """
         if self.version >= "4.20" and (self._column_storage or 1):
             return self._extend_column_oriented(index, signals)
@@ -6174,25 +6173,25 @@ class MDF4(MDF_Common):
 
         Examples
         --------
-        >>> # case 1 conversion type None
+        >>> from asammdf import MDF, Signal
+        >>> import numpy as np
         >>> s1 = np.array([1, 2, 3, 4, 5])
         >>> s2 = np.array([-1, -2, -3, -4, -5])
         >>> s3 = np.array([0.1, 0.04, 0.09, 0.16, 0.25])
         >>> t = np.array([0.001, 0.002, 0.003, 0.004, 0.005])
-        >>> names = ['Positive', 'Negative', 'Float']
-        >>> units = ['+', '-', '.f']
         >>> s1 = Signal(samples=s1, timestamps=t, unit='+', name='Positive')
         >>> s2 = Signal(samples=s2, timestamps=t, unit='-', name='Negative')
         >>> s3 = Signal(samples=s3, timestamps=t, unit='flts', name='Floats')
-        >>> mdf = MDF4('new.mdf')
-        >>> mdf.append([s1, s2, s3], comment='created by asammdf v1.1.0')
+        >>> mdf = MDF(version='4.10')
+        >>> mdf.append([s1, s2, s3], comment='created by asammdf')
         >>> t = np.array([0.006, 0.007, 0.008, 0.009, 0.010])
-        >>> # extend without invalidation bits
-        >>> mdf2.extend(0, [(t, None), (s1, None), (s2, None), (s3, None)])
-        >>> # some invaldiation btis
-        >>> s1_inv = np.array([0,0,0,1,1], dtype=np.bool)
-        >>> mdf2.extend(0, [(t, None), (s1.samples, None), (s2.samples, None), (s3.samples, None)])
 
+        >>> # extend without invalidation bits
+        >>> mdf.extend(0, [(t, None), (s1.samples, None), (s2.samples, None), (s3.samples, None)])
+
+        >>> # some invalidation bits
+        >>> s1_inv = np.array([0, 0, 0, 1, 1], dtype=np.bool)
+        >>> mdf.extend(0, [(t, None), (s1.samples, s1_inv), (s2.samples, None), (s3.samples, None)])
         """
         gp = self.groups[index]
         if not signals:
@@ -6749,6 +6748,9 @@ class MDF4(MDF_Common):
         * if the channel name is not found
         * if the group index is out of range
         * if the channel index is out of range
+        * if there are multiple channel occurrences in the file and the arguments
+          *name*, *group*, *index* are ambiguous. This behaviour can be turned off
+          by setting raise_on_multiple_occurrences to *False*.
 
         Examples
         --------
@@ -6761,49 +6763,37 @@ class MDF4(MDF_Common):
         ...     sigs = [Signal(s*(i*10+j), t, name='Sig') for j in range(1, 4)]
         ...     mdf.append(sigs)
         ...
-        >>> # first group and channel index of the specified channel name
-        ...
         >>> mdf.get('Sig')
-        UserWarning: Multiple occurrences for channel "Sig". Using first occurrence from data group 4. Provide both "group" and "index" arguments to select another data group
-        <Signal Sig:
-                samples=[ 1.  1.  1.  1.  1.]
-                timestamps=[0 1 2 3 4]
-                unit=""
-                info=None
-                comment="">
-        >>> # first channel index in the specified group
-        ...
+        MdfException: Multiple occurrences for channel "Sig": ((0, 1), (0, 2),
+        (0, 3), (1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (2, 3), (3, 1), (3, 2),
+        (3, 3)). Provide both "group" and "index" arguments to select another
+        data group
+        >>>
         >>> mdf.get('Sig', 1)
-        <Signal Sig:
-                samples=[ 11.  11.  11.  11.  11.]
-                timestamps=[0 1 2 3 4]
-                unit=""
-                info=None
-                comment="">
-        >>> # channel named Sig from group 1 channel index 2
-        ...
+        MdfException: Multiple occurrences for channel "Sig": ((1, 1), (1, 2),
+        (1, 3)). Provide both "group" and "index" arguments to select another
+        data group
+        >>>
+        >>> # channel named Sig from group 1, channel index 2
         >>> mdf.get('Sig', 1, 2)
         <Signal Sig:
                 samples=[ 12.  12.  12.  12.  12.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
-        >>> # channel index 1 or group 2
-        ...
+        >>>
+        >>> # group 2, channel index 1
         >>> mdf.get(None, 2, 1)
         <Signal Sig:
                 samples=[ 21.  21.  21.  21.  21.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         >>> mdf.get(group=2, index=1)
         <Signal Sig:
                 samples=[ 21.  21.  21.  21.  21.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
 
         """
@@ -9309,10 +9299,8 @@ class MDF4(MDF_Common):
 
         Examples
         --------
-        >>> mdf = MDF4('test.mdf')
+        >>> mdf = MDF('test.mdf')
         >>> mdf.info()
-
-
         """
         info = {
             "version": self.version,

--- a/src/asammdf/blocks/source_utils.py
+++ b/src/asammdf/blocks/source_utils.py
@@ -34,7 +34,7 @@ class Source:
     BUS_TYPE_USB = v4c.BUS_TYPE_USB
 
     def __init__(self, name: str, path: str, comment: str, source_type: int, bus_type: int) -> None:
-        """Commons reprezentation for source information
+        """Common representation for source information.
 
         Attributes
         ----------

--- a/src/asammdf/blocks/utils.py
+++ b/src/asammdf/blocks/utils.py
@@ -204,7 +204,7 @@ def extract_xml_comment(comment: str) -> str:
             if common_properties is not None:
                 comments: list[str] = []
                 for e in common_properties:
-                    field = f'{e.get("name")}: {e.text}'
+                    field = f"{e.get('name')}: {e.text}"
                     comments.append(field)
                 comment = "\n".join(field)
             else:
@@ -1049,7 +1049,7 @@ def validate_version_argument(version: str, hint: int = 4) -> str:
             valid_version = "3.30"
         else:
             valid_version = "4.10"
-        message = 'Unknown mdf version "{}".' " The available versions are {};" ' automatically using version "{}"'
+        message = 'Unknown mdf version "{}". The available versions are {}; automatically using version "{}"'
         message = message.format(version, SUPPORTED_VERSIONS, valid_version)
         logger.warning(message)
     else:
@@ -2467,16 +2467,15 @@ def timeit(func: Callable[_Params, _Ret]) -> Callable[_Params, _Ret]:
         t2 = perf_counter()
         delta = t2 - t1
         if delta >= 1e-3:
-            print(f"CALL {func.__qualname__}: {delta*1e3:.3f} ms")
+            print(f"CALL {func.__qualname__}: {delta * 1e3:.3f} ms")
         else:
-            print(f"CALL {func.__qualname__}: {delta*1e6:.3f} us")
+            print(f"CALL {func.__qualname__}: {delta * 1e6:.3f} us")
         return ret
 
     return timed
 
 
 class Timer:
-
     def __init__(self, name: str = "") -> None:
         self.name = name or str(id(self))
         self.count = 0

--- a/src/asammdf/blocks/v2_v3_blocks.py
+++ b/src/asammdf/blocks/v2_v3_blocks.py
@@ -3249,7 +3249,7 @@ class TextBlock:
         return v23c.COMMON_p(self.id, self.block_len) + self.text
 
     def __repr__(self) -> str:
-        return f"TextBlock(id={self.id!r},block_len={self.block_len}, text={self.text!r})"
+        return f"TextBlock(id={self.id!r}, block_len={self.block_len}, text={self.text!r})"
 
 
 class TriggerBlock:

--- a/src/asammdf/blocks/v2_v3_blocks.py
+++ b/src/asammdf/blocks/v2_v3_blocks.py
@@ -669,9 +669,7 @@ display names: {self.display_names}
 address: {hex(self.address)}
 comment: {self.comment}
 
-""".split(
-            "\n"
-        )
+""".split("\n")
 
         keys = (
             "id",
@@ -1072,7 +1070,7 @@ class ChannelConversion(_ChannelConversionBase):
                     self.referenced_blocks = conversion.referenced_blocks
 
                 else:
-                    float_values: tuple[float, ...] = unpack_from(f"<{2*nr}d", block, v23c.CC_COMMON_SHORT_SIZE)
+                    float_values: tuple[float, ...] = unpack_from(f"<{2 * nr}d", block, v23c.CC_COMMON_SHORT_SIZE)
                     for i in range(nr):
                         (self[f"raw_{i}"], self[f"phys_{i}"]) = (
                             float_values[i * 2],
@@ -1420,9 +1418,7 @@ class ChannelConversion(_ChannelConversionBase):
         lines = f"""
 address: {hex(self.address)}
 
-""".split(
-            "\n"
-        )
+""".split("\n")
 
         for key in keys:
             val = getattr(self, key)
@@ -1713,7 +1709,7 @@ address: {hex(self.address)}
             fmt = v23c.FMT_CONVERSION_EXPO_LOGH
         elif conv in (v23c.CONVERSION_TYPE_TABI, v23c.CONVERSION_TYPE_TAB):
             nr = self.ref_param_nr
-            fmt = v23c.FMT_CONVERSION_COMMON + f"{2*nr}d"
+            fmt = v23c.FMT_CONVERSION_COMMON + f"{2 * nr}d"
         elif conv == v23c.CONVERSION_TYPE_RTABX:
             nr = self.ref_param_nr
             fmt = v23c.FMT_CONVERSION_COMMON + "2dI" * nr
@@ -2132,9 +2128,7 @@ class ChannelExtension:
         lines = f"""
 address: {hex(self.address)}
 
-""".split(
-            "\n"
-        )
+""".split("\n")
 
         for key in keys:
             val = getattr(self, key)
@@ -2422,9 +2416,7 @@ class ChannelGroup:
 address: {hex(self.address)}
 comment: {self.comment}
 
-""".split(
-            "\n"
-        )
+""".split("\n")
 
         for key in keys:
             if not hasattr(self, key):
@@ -3086,7 +3078,7 @@ class HeaderBlock:
                 tz_offset_sign = "-" if self.tz_offset < 0 else "+"
                 tz_information = f"[GMT{tz_offset_sign}{abs(self.tz_offset):.2f} DST+{0:.2f}h]"
 
-        start_time = f'local time = {self.start_time.strftime("%d-%b-%Y %H:%M:%S + %fu")} {tz_information}'
+        start_time = f"local time = {self.start_time.strftime('%d-%b-%Y %H:%M:%S + %fu')} {tz_information}"
         return start_time
 
     def __getitem__(self, item: str) -> object:
@@ -3257,7 +3249,7 @@ class TextBlock:
         return v23c.COMMON_p(self.id, self.block_len) + self.text
 
     def __repr__(self) -> str:
-        return f"TextBlock(id={self.id!r}," f"block_len={self.block_len}, " f"text={self.text!r})"
+        return f"TextBlock(id={self.id!r},block_len={self.block_len}, text={self.text!r})"
 
 
 class TriggerBlock:

--- a/src/asammdf/blocks/v2_v3_blocks.py
+++ b/src/asammdf/blocks/v2_v3_blocks.py
@@ -2877,7 +2877,7 @@ class HeaderBlock:
 
     @property
     def start_time(self) -> datetime:
-        """getter and setter the measurement start timestamp
+        """Getter and setter of the measurement start timestamp.
 
         Returns
         -------

--- a/src/asammdf/blocks/v4_blocks.py
+++ b/src/asammdf/blocks/v4_blocks.py
@@ -1246,7 +1246,7 @@ class Channel:
         return f"""<Channel (name: {self.name}, unit: {self.unit}, comment: {self.comment}, address: {hex(self.address)},
     conversion: {self.conversion},
     source: {self.source},
-    fields: {', '.join(block_fields(self))})>"""
+    fields: {", ".join(block_fields(self))})>"""
 
     def metadata(self) -> str:
         if self.block_len == v4c.CN_BLOCK_SIZE:
@@ -1302,9 +1302,7 @@ address: {hex(self.address)}
 comment: {self.comment}
 unit: {self.unit}
 
-""".split(
-            "\n"
-        )
+""".split("\n")
 
         for key in keys:
             val = getattr(self, key)
@@ -2143,9 +2141,7 @@ name: {self.acq_name}
 address: {hex(self.address)}
 comment: {self.comment}
 
-""".split(
-            "\n"
-        )
+""".split("\n")
 
         for key in keys:
             val = getattr(self, key)
@@ -4055,9 +4051,7 @@ address: {hex(self.address)}
 comment: {self.comment}
 formula: {self.formula}
 
-""".split(
-            "\n"
-        )
+""".split("\n")
         for key in keys:
             val = getattr(self, key)
             if key.endswith("addr") or key.startswith("text_"):
@@ -5136,7 +5130,7 @@ class EventBlock(_EventBlockBase):
             elif addr in cg_map:
                 self.scopes.append(cg_map[addr])
             else:
-                message = "{} is not a valid CNBLOCK or CGBLOCK " "address for the event scope"
+                message = "{} is not a valid CNBLOCK or CGBLOCK address for the event scope"
                 message = message.format(hex(addr))
                 logger.exception(message)
                 raise MdfException(message)
@@ -5794,14 +5788,14 @@ class HeaderBlock:
 
             tz_information = f"[GMT{tz_offset_sign}{tz_offset:.2f} DST{dst_offset_sign}{dst_offset:.2f}h]"
 
-            start_time = f'local time = {self.start_time.strftime("%d-%b-%Y %H:%M:%S + %fu")} {tz_information}'
+            start_time = f"local time = {self.start_time.strftime('%d-%b-%Y %H:%M:%S + %fu')} {tz_information}"
 
         else:
             tzinfo = self.start_time.tzinfo
 
             if tzinfo is None:
                 return (
-                    f'local time = {self.start_time.strftime("%d-%b-%Y %H:%M:%S + %fu")} (no timezone info available)'
+                    f"local time = {self.start_time.strftime('%d-%b-%Y %H:%M:%S + %fu')} (no timezone info available)"
                 )
 
             dst = tzinfo.dst(self.start_time)
@@ -5819,7 +5813,7 @@ class HeaderBlock:
 
             tz_information = f"[assumed GMT{tz_offset_sign}{tz_offset:.2f} DST{dst_offset_sign}{dst_offset:.2f}h]"
 
-            start_time = f'local time = {self.start_time.strftime("%d-%b-%Y %H:%M:%S + %fu")} {tz_information}'
+            start_time = f"local time = {self.start_time.strftime('%d-%b-%Y %H:%M:%S + %fu')} {tz_information}"
 
         return start_time
 
@@ -6325,9 +6319,7 @@ path: {self.path}
 address: {hex(self.address)}
 comment: {self.comment}
 
-""".split(
-            "\n"
-        )
+""".split("\n")
         for key in v4c.KEYS_SOURCE_INFORMATION:
             val = getattr(self, key)
             if key.endswith("addr") or key.startswith("text_"):

--- a/src/asammdf/blocks/v4_blocks.py
+++ b/src/asammdf/blocks/v4_blocks.py
@@ -5440,7 +5440,7 @@ class FileHistory:
 
     @property
     def time_stamp(self) -> datetime:
-        """getter and setter the file history timestamp
+        """Getter and setter of the file history timestamp.
 
         Returns
         -------
@@ -5733,7 +5733,7 @@ class HeaderBlock:
 
     @property
     def start_time(self) -> datetime:
-        """getter and setter the measurement start timestamp
+        """Getter and setter of the measurement start timestamp.
 
         Returns
         -------

--- a/src/asammdf/gui/dialogs/advanced_search.py
+++ b/src/asammdf/gui/dialogs/advanced_search.py
@@ -412,7 +412,6 @@ class AdvancedSearch(Ui_SearchDialog, QtWidgets.QDialog):
 
         iterator = QtWidgets.QTreeWidgetItemIterator(self.selection)
         while item := iterator.value():
-
             data = tuple(item.text(i) for i in range(self.columns))
             selection.add(data)
 

--- a/src/asammdf/gui/dialogs/messagebox.py
+++ b/src/asammdf/gui/dialogs/messagebox.py
@@ -7,7 +7,6 @@ DEFAULT_TIMEOUT = int(os.environ.get("ASAMMDF_ERROR_DIALOG_TIMEOUT", 60))
 
 class MessageBox(QtWidgets.QMessageBox):
     def __init__(self, *args, **kwargs):
-
         self.timeout = kwargs.pop("timeout", DEFAULT_TIMEOUT)
         informative_text = kwargs.pop("informative_text", "")
         detailed_text = kwargs.pop("detailed_text", "")
@@ -58,13 +57,13 @@ class MessageBox(QtWidgets.QMessageBox):
 * * *
 
 This message will be closed in {self.timeout}s
-* Default button - [{self.defaultButton().text().strip('&')}]
+* Default button - [{self.defaultButton().text().strip("&")}]
 * Abort the countdown - [F1]"""
                 )
             else:
                 self.setText(
                     f"{self.original_text}\n\nThis message will be closed in {self.timeout}s\n"
-                    f'Default button - [{self.defaultButton().text().strip("&")}]\n'
+                    f"Default button - [{self.defaultButton().text().strip('&')}]\n"
                     "Abort the countdown - [F1]"
                 )
         else:
@@ -137,13 +136,13 @@ This message will be closed in {self.timeout}s
 * * *
 
 This message will be closed in {self.timeout}s
-* Default button - [{self.defaultButton().text().strip('&')}]
+* Default button - [{self.defaultButton().text().strip("&")}]
 * Abort the countdown - [F1]"""
                     )
                 else:
                     self.setText(
                         f"{self.original_text}\n\nThis message will be closed in {self.timeout}s\n"
-                        f'Default button - [{self.defaultButton().text().strip("&")}]\n'
+                        f"Default button - [{self.defaultButton().text().strip('&')}]\n"
                         "Abort the countdown - [F1]"
                     )
             else:

--- a/src/asammdf/gui/utils.py
+++ b/src/asammdf/gui/utils.py
@@ -300,7 +300,6 @@ class QWorkerThread(QtCore.QThread):
 
 
 class ProgressDialog(QtWidgets.QProgressDialog):
-
     NONE = NONE
     TERMINATED = TERMINATED
 
@@ -379,7 +378,6 @@ class ProgressDialog(QtWidgets.QProgressDialog):
             QtCore.QTimer.singleShot(50, self.close)
 
     def close(self, reject=False):
-
         if self.thread and not self.thread.isFinished():
             self.thread.requestInterruption()
 
@@ -797,7 +795,7 @@ def computation_to_python_function(description):
         for match in VARIABLE.finditer(exp):
             name = match.group("var")
             if name not in translation:
-                arg = f"arg{len(translation)+1}"
+                arg = f"arg{len(translation) + 1}"
                 translation[name] = arg
                 args.append(f"{arg}=0")
                 fargs[arg] = [name.strip("}{")]
@@ -1124,7 +1122,7 @@ def value_as_bin(value, dtype):
 
     nibles = []
     for byte in byte_string:
-        nibles.extend((f"{byte >> 4:04b}", f"{byte & 0xf:04b}"))
+        nibles.extend((f"{byte >> 4:04b}", f"{byte & 0xF:04b}"))
 
     return ".".join(nibles)
 
@@ -1209,7 +1207,6 @@ def generate_python_variables(definition: str, in_globals: Union[dict, None] = N
         if contains_imports(definition):
             trace = "Cannot use import statements in the definition"
         else:
-
             _globals = in_globals or generate_python_function_globals()
 
             try:
@@ -1221,7 +1218,6 @@ def generate_python_variables(definition: str, in_globals: Union[dict, None] = N
 
 
 def generate_python_function_globals() -> dict:
-
     func_globals = {
         "bisect": bisect,
         "collections": collections,

--- a/src/asammdf/gui/widgets/batch.py
+++ b/src/asammdf/gui/widgets/batch.py
@@ -249,7 +249,7 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
 
         # scrambling self.mdf
         for i, source_file in enumerate(source_files):
-            progress.signals.setLabelText.emit(f"Scrambling file {i+1} of {count}\n{source_file}")
+            progress.signals.setLabelText.emit(f"Scrambling file {i + 1} of {count}\n{source_file}")
 
             result = mdf_module.MDF.scramble(name=source_file, progress=progress)
             if result is TERMINATED:
@@ -337,7 +337,7 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
         progress.signals.setMaximum.emit(count)
 
         for i, (file, source_file) in enumerate(zip(files, source_files)):
-            progress.signals.setLabelText.emit(f"Extracting Bus logging from file {i+1} of {count}\n{source_file}")
+            progress.signals.setLabelText.emit(f"Extracting Bus logging from file {i + 1} of {count}\n{source_file}")
 
             if not isinstance(file, mdf_module.MDF):
                 mdf = mdf_module.MDF(file)
@@ -369,10 +369,10 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
                 message += [
                     "",
                     f'Summary of "{mdf.name}":',
-                    f'- {found_id_count} of {len(call_info["total_unique_ids"])} IDs in the MDF4 file were matched in the DBC and converted',
+                    f"- {found_id_count} of {len(call_info['total_unique_ids'])} IDs in the MDF4 file were matched in the DBC and converted",
                 ]
                 if call_info["unknown_id_count"]:
-                    message.append(f'- {call_info["unknown_id_count"]} unknown IDs in the MDF4 file')
+                    message.append(f"- {call_info['unknown_id_count']} unknown IDs in the MDF4 file")
                 else:
                     message.append("- no unknown IDs inf the MDF4 file")
 
@@ -407,7 +407,7 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
             file_name = source_file.with_suffix(".bus_logging.mdf" if version < "4.00" else ".bus_logging.mf4")
 
             # then save it
-            progress.signals.setLabelText.emit(f'Saving extracted Bus logging file {i+1} to "{file_name}"')
+            progress.signals.setLabelText.emit(f'Saving extracted Bus logging file {i + 1} to "{file_name}"')
 
             result = mdf_.save(
                 dst=file_name,
@@ -531,7 +531,7 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
         message = []
 
         for i, (file, source_file) in enumerate(zip(files, source_files)):
-            progress.signals.setLabelText.emit(f"Extracting Bus logging from file {i+1} of {count}")
+            progress.signals.setLabelText.emit(f"Extracting Bus logging from file {i + 1} of {count}")
 
             if not isinstance(file, mdf_module.MDF):
                 mdf = mdf_module.MDF(file)
@@ -562,10 +562,10 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
                 message += [
                     "",
                     f'Summary of "{mdf.name}":',
-                    f'- {found_id_count} of {len(call_info["total_unique_ids"])} IDs in the MDF4 file were matched in the DBC and converted',
+                    f"- {found_id_count} of {len(call_info['total_unique_ids'])} IDs in the MDF4 file were matched in the DBC and converted",
                 ]
                 if call_info["unknown_id_count"]:
-                    message.append(f'- {call_info["unknown_id_count"]} unknown IDs in the MDF4 file')
+                    message.append(f"- {call_info['unknown_id_count']} unknown IDs in the MDF4 file")
                 else:
                     message.append("- no unknown IDs inf the MDF4 file")
 
@@ -591,7 +591,7 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
             file_name = source_file.with_suffix(".bus_logging.csv")
 
             # then save it
-            progress.signals.setLabelText.emit(f'Saving extracted Bus logging file {i+1} to "{file_name}"')
+            progress.signals.setLabelText.emit(f'Saving extracted Bus logging file {i + 1} to "{file_name}"')
 
             mdf_.configure(
                 integer_interpolation=self.integer_interpolation,
@@ -939,7 +939,7 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
             if progress.stop:
                 return []
 
-            progress.signals.setLabelText.emit(f"Preparing the file {i+1} of {count}\n{file_name.name}")
+            progress.signals.setLabelText.emit(f"Preparing the file {i + 1} of {count}\n{file_name.name}")
             try:
                 mdf = self._as_mdf(file_name)
             except:
@@ -1058,7 +1058,6 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
 
                     signals = set()
                     while item := iterator.value():
-
                         if item.checkState(0) == QtCore.Qt.CheckState.Checked:
                             signals.add(item.entry)
 
@@ -1136,7 +1135,6 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
                         iterator += 1
                 else:
                     while item := iterator.value():
-
                         if item.checkState(0) == QtCore.Qt.CheckState.Checked:
                             signals.add(item.entry)
 
@@ -1501,7 +1499,7 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
                 icon = QtGui.QIcon()
                 icon.addPixmap(QtGui.QPixmap(":/cut.png"), QtGui.QIcon.Mode.Normal, QtGui.QIcon.State.Off)
                 progress.signals.setWindowIcon.emit(icon)
-                progress.signals.setWindowTitle.emit(f"Cutting measurement {mdf_index+1} of {count}")
+                progress.signals.setWindowTitle.emit(f"Cutting measurement {mdf_index + 1} of {count}")
                 progress.signals.setLabelText.emit(
                     f"Cutting from {opts.cut_start}s to {opts.cut_stop}s from \n{source_file}"
                 )
@@ -1541,7 +1539,7 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
                 icon = QtGui.QIcon()
                 icon.addPixmap(QtGui.QPixmap(":/resample.png"), QtGui.QIcon.Mode.Normal, QtGui.QIcon.State.Off)
                 progress.signals.setWindowIcon.emit(icon)
-                progress.signals.setWindowTitle.emit(f"Resampling measurement {mdf_index+1} of {count}")
+                progress.signals.setWindowTitle.emit(f"Resampling measurement {mdf_index + 1} of {count}")
                 progress.signals.setLabelText.emit(message)
 
                 # resample self.mdf
@@ -1576,7 +1574,7 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
                         QtGui.QIcon.State.Off,
                     )
                     progress.signals.setWindowIcon.emit(icon)
-                    progress.signals.setWindowTitle.emit(f"Converting measurement {mdf_index+1} of {count}")
+                    progress.signals.setWindowTitle.emit(f"Converting measurement {mdf_index + 1} of {count}")
                     progress.signals.setLabelText.emit(f'Converting "{source_file}" from {mdf.version} to {version}')
 
                     # convert self.mdf
@@ -1621,8 +1619,8 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
                 icon = QtGui.QIcon()
                 icon.addPixmap(QtGui.QPixmap(":/save.png"), QtGui.QIcon.Mode.Normal, QtGui.QIcon.State.Off)
                 progress.signals.setWindowIcon.emit(icon)
-                progress.signals.setWindowTitle.emit(f"Saving measurement {mdf_index+1} of {count}")
-                progress.signals.setLabelText.emit(f"Saving output file {mdf_index+1} of {count}\n{source_file}")
+                progress.signals.setWindowTitle.emit(f"Saving measurement {mdf_index + 1} of {count}")
+                progress.signals.setLabelText.emit(f"Saving output file {mdf_index + 1} of {count}\n{source_file}")
 
                 result = mdf.save(
                     dst=file_name,
@@ -1653,9 +1651,9 @@ class BatchWidget(Ui_batch_widget, QtWidgets.QWidget):
                 icon = QtGui.QIcon()
                 icon.addPixmap(QtGui.QPixmap(":/export.png"), QtGui.QIcon.Mode.Normal, QtGui.QIcon.State.Off)
                 progress.signals.setWindowIcon.emit(icon)
-                progress.signals.setWindowTitle.emit(f"export_batch measurement {mdf_index+1} of {count}")
+                progress.signals.setWindowTitle.emit(f"export_batch measurement {mdf_index + 1} of {count}")
                 progress.signals.setLabelText.emit(
-                    f"export_batching measurement {mdf_index+1} of {count} to {output_format} (be patient this might take a while)\n{source_file}"
+                    f"export_batching measurement {mdf_index + 1} of {count} to {output_format} (be patient this might take a while)\n{source_file}"
                 )
 
                 delimiter = self.delimiter.text() or ","
@@ -1908,7 +1906,6 @@ MultiRasterSeparator;&
 
             elif self.filter_view.currentText() == "Natural sort":
                 while item := iterator.value():
-
                     channel_name = item.text(0)
                     if channel_name in channels:
                         item.setCheckState(0, QtCore.Qt.CheckState.Checked)

--- a/src/asammdf/gui/widgets/file.py
+++ b/src/asammdf/gui/widgets/file.py
@@ -468,7 +468,7 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
                     for flag, string in FLAG_AT_TO_STRING.items():
                         if attachment.flags & flag:
                             flags.append(string)
-                    text = f'{attachment.flags} [0x{attachment.flags:X}= {", ".join(flags)}]'
+                    text = f"{attachment.flags} [0x{attachment.flags:X}= {', '.join(flags)}]"
                 else:
                     text = "0"
                 field.setText(1, text)
@@ -483,11 +483,11 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
                 if size <= 1 << 10:
                     text = f"{size} B"
                 elif size <= 1 << 20:
-                    text = f"{size/1024:.1f} KB"
+                    text = f"{size / 1024:.1f} KB"
                 elif size <= 1 << 30:
-                    text = f"{size/1024/1024:.1f} MB"
+                    text = f"{size / 1024 / 1024:.1f} MB"
                 else:
-                    text = f"{size/1024/1024/1024:.1f} GB"
+                    text = f"{size / 1024 / 1024 / 1024:.1f} GB"
 
                 field = QtWidgets.QTreeWidgetItem()
                 field.setText(0, "Size")
@@ -606,7 +606,6 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
 
         if widget.mode == "Internal file structure":
             while item := iterator.value():
-
                 if item.entry[1] != 0xFFFFFFFFFFFFFFFF:
                     if item.checkState(0) == QtCore.Qt.CheckState.Checked:
                         signals.add(item.entry)
@@ -614,7 +613,6 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
                 iterator += 1
         else:
             while item := iterator.value():
-
                 if item.checkState(0) == QtCore.Qt.CheckState.Checked:
                     signals.add(item.entry)
 
@@ -879,7 +877,6 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
 
                     signals = set()
                     while item := iterator.value():
-
                         if item.checkState(0) == QtCore.Qt.CheckState.Checked:
                             signals.add((item.text(0), *item.entry))
 
@@ -911,7 +908,6 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
                 else:
                     iterator = QtWidgets.QTreeWidgetItemIterator(widget)
                     while item := iterator.value():
-
                         if item.entry in result:
                             item.setCheckState(0, QtCore.Qt.CheckState.Checked)
                             names.add((result[item.entry], *item.entry))
@@ -999,7 +995,6 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
                 iterator += 1
         else:
             while item := iterator.value():
-
                 if item.checkState(0) == QtCore.Qt.CheckState.Checked:
                     signals.append(item.text(0))
 
@@ -1267,7 +1262,7 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
             self.loaded_display_file = Path(info.get("display_file_name", "")), b""
 
             self.functions.update(info.get("functions", {}))
-            self.global_variables = f'{self.global_variables}\n{info.get("global_variables", "")}'
+            self.global_variables = f"{self.global_variables}\n{info.get('global_variables', '')}"
             self.global_variables = "\n".join([line for line in self.global_variables.splitlines() if line])
 
         if channels:
@@ -1289,7 +1284,6 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
                     iterator += 1
             else:
                 while item := iterator.value():
-
                     channel_name = item.text(0)
                     if channel_name in channels:
                         item.setCheckState(0, QtCore.Qt.CheckState.Checked)
@@ -1333,7 +1327,7 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
                                 }
 
             if new_functions or info.get("global_variables", "") != self.global_variables:
-                self.update_functions({}, new_functions, f'{self.global_variables}\n{info.get("global_variables", "")}')
+                self.update_functions({}, new_functions, f"{self.global_variables}\n{info.get('global_variables', '')}")
 
         self.clear_windows()
 
@@ -1343,7 +1337,6 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
             count = len(windows)
 
             if show_progress:
-
                 progress = setup_progress(
                     parent=self,
                     title="Loading display windows",
@@ -1763,7 +1756,6 @@ MultiRasterSeparator;&
                         iterator += 1
                 else:
                     while item := iterator.value():
-
                         if item.checkState(0) == QtCore.Qt.CheckState.Checked:
                             group, index = item.entry
                             ch = self.mdf.groups[group].channels[index]
@@ -1920,10 +1912,10 @@ MultiRasterSeparator;&
 
             message += [
                 f"{bus} bus summary:",
-                f'- {found_id_count} of {len(call_info["total_unique_ids"])} IDs in the MDF4 file were matched in the DBC and converted',
+                f"- {found_id_count} of {len(call_info['total_unique_ids'])} IDs in the MDF4 file were matched in the DBC and converted",
             ]
             if call_info["unknown_id_count"]:
-                message.append(f'- {call_info["unknown_id_count"]} unknown IDs in the MDF4 file')
+                message.append(f"- {call_info['unknown_id_count']} unknown IDs in the MDF4 file")
             else:
                 message.append("- no unknown IDs inf the MDF4 file")
 
@@ -2119,10 +2111,10 @@ MultiRasterSeparator;&
 
             message += [
                 f"{bus} bus summary:",
-                f'- {found_id_count} of {len(call_info["total_unique_ids"])} IDs in the MDF4 file were matched in the DBC and converted',
+                f"- {found_id_count} of {len(call_info['total_unique_ids'])} IDs in the MDF4 file were matched in the DBC and converted",
             ]
             if call_info["unknown_id_count"]:
-                message.append(f'- {call_info["unknown_id_count"]} unknown IDs in the MDF4 file')
+                message.append(f"- {call_info['unknown_id_count']} unknown IDs in the MDF4 file")
             else:
                 message.append("- no unknown IDs inf the MDF4 file")
 
@@ -3070,7 +3062,7 @@ MultiRasterSeparator;&
             return MessageBox.warning(
                 self,
                 "Wrong file type",
-                "The display file can only be embedded in .mf4 or .mf4z files" f"\n{original_file_name}",
+                f"The display file can only be embedded in .mf4 or .mf4z files\n{original_file_name}",
             )
 
         _password = self.mdf._password
@@ -3299,7 +3291,7 @@ MultiRasterSeparator;&
                     for flag, string in FLAG_AT_TO_STRING.items():
                         if attachment.flags & flag:
                             flags.append(string)
-                    text = f'{attachment.flags} [0x{attachment.flags:X}= {", ".join(flags)}]'
+                    text = f"{attachment.flags} [0x{attachment.flags:X}= {', '.join(flags)}]"
                 else:
                     text = "0"
                 field.setText(1, text)

--- a/src/asammdf/gui/widgets/formated_axis.py
+++ b/src/asammdf/gui/widgets/formated_axis.py
@@ -93,9 +93,9 @@ class FormatedAxis(pg.AxisItem):
 
                 if isinstance(nv, bytes):
                     try:
-                        strns.append(f'{val}={nv.decode("utf-8", errors="replace")}')
+                        strns.append(f"{val}={nv.decode('utf-8', errors='replace')}")
                     except:
-                        strns.append(f'{val}={nv.decode("latin-1", errors="replace")}')
+                        strns.append(f"{val}={nv.decode('latin-1', errors='replace')}")
                 else:
                     strns.append(val)
         else:

--- a/src/asammdf/gui/widgets/functions_manager.py
+++ b/src/asammdf/gui/widgets/functions_manager.py
@@ -372,7 +372,6 @@ def MyAverage(main_clock=0, p_FL=0, p_FR=0, p_RL=0, p_RR=0, vehicle_speed=0, t=0
         return names
 
     def store_definition(self, *args):
-
         item = self.functions_list.currentItem()
         if not item:
             return
@@ -383,15 +382,13 @@ def MyAverage(main_clock=0, p_FL=0, p_FR=0, p_RL=0, p_RR=0, vehicle_speed=0, t=0
 
         ok, func = self.check_syntax(silent=True)
         if ok:
-
             func_name = func.__name__
 
             if current_name != func_name and func_name in self.definitions:
                 MessageBox.information(
                     self,
                     "Invalid function name",
-                    f'The name "{func_name}" is already given to another function.\n'
-                    "The function names must be unique",
+                    f'The name "{func_name}" is already given to another function.\nThe function names must be unique',
                 )
 
             else:

--- a/src/asammdf/gui/widgets/mdi_area.py
+++ b/src/asammdf/gui/widgets/mdi_area.py
@@ -514,7 +514,6 @@ def get_comparison_mime(data, uuids):
 
 
 class MdiAreaMixin:
-
     def addSubWindow(self, window):
         geometry = window.geometry()
         geometry.setSize(QtCore.QSize(400, 400))
@@ -533,7 +532,6 @@ class MdiAreaMixin:
             widget.close()
 
     def window_moved(self, window, new_position, old_position):
-
         snap = False
 
         window_geometry = window.geometry()
@@ -641,7 +639,6 @@ class MdiAreaMixin:
                 break
 
         else:
-
             # left edge of other windows growing and snapping
             snap_candidates = []
 
@@ -670,7 +667,6 @@ class MdiAreaMixin:
                 snap = True
                 break
         else:
-
             # top edge of other windows snapping
             snap_candidates = []
 
@@ -744,7 +740,6 @@ class MdiAreaMixin:
                 y_delta = -y_delta
 
         if previous_x is not None:
-
             for sub in sub_windows:
                 geometry = sub.geometry()
                 if abs(geometry.x() - previous_x) <= SNAP_PIXELS_DISTANCE:
@@ -755,7 +750,6 @@ class MdiAreaMixin:
                     sub.setGeometry(geometry)
 
         if previous_y is not None:
-
             for sub in sub_windows:
                 geometry = sub.geometry()
                 if abs(geometry.y() - previous_y) <= SNAP_PIXELS_DISTANCE:
@@ -1060,7 +1054,6 @@ class WithMDIArea:
             current_count = len(widget.plot.signals)
             count = len(names)
         elif isinstance(widget, XY):
-
             if names:
                 name = names[0]
             else:
@@ -1220,7 +1213,7 @@ class WithMDIArea:
                             # MainWindow => comparison plots
 
                             sig.tooltip = f"{sig.name}\n@ {file.file_name}"
-                            sig.name = f"{file_index+1}: {sig.name}"
+                            sig.name = f"{file_index + 1}: {sig.name}"
 
                     signals.extend(selected_signals)
 
@@ -1295,7 +1288,7 @@ class WithMDIArea:
                             # MainWindow => comparison plots
 
                             sig.tooltip = f"{sig.name}\n@ {file.file_name}"
-                            sig.name = f"{file_index+1}: {sig.name}"
+                            sig.name = f"{file_index + 1}: {sig.name}"
 
                         if sig.samples.dtype.kind not in "SU" and (
                             sig.samples.dtype.names or len(sig.samples.shape) > 1
@@ -1519,7 +1512,6 @@ class WithMDIArea:
         dfs = []
 
         if self.mdf.version >= "4.00":
-
             groups_count = len(self.mdf.groups)
 
             for index in range(groups_count):
@@ -1777,7 +1769,6 @@ class WithMDIArea:
     def _add_flexray_bus_trace_window(self, ranges=None):
         items = []
         if self.mdf.version >= "4.00":
-
             groups_count = len(self.mdf.groups)
 
             for index in range(groups_count):
@@ -2035,7 +2026,6 @@ class WithMDIArea:
     def _add_lin_bus_trace_window(self, ranges=None):
         dfs = []
         if self.mdf.version >= "4.00":
-
             groups_count = len(self.mdf.groups)
 
             for index in range(groups_count):
@@ -2303,7 +2293,6 @@ class WithMDIArea:
         return trace
 
     def _add_numeric_window(self, names):
-
         if names and isinstance(names[0], str):
             signals_ = [
                 (
@@ -2390,7 +2379,7 @@ class WithMDIArea:
                     # MainWindow => comparison plots
 
                     sig.tooltip = f"{sig.name}\n@ {file.file_name}"
-                    sig.name = f"{file_index+1}: {sig.name}"
+                    sig.name = f"{file_index + 1}: {sig.name}"
 
             signals.extend(selected_signals)
 
@@ -2579,7 +2568,7 @@ class WithMDIArea:
                     # MainWindow => comparison plots
 
                     sig.tooltip = f"{sig.name}\n@ {file.file_name}"
-                    sig.name = f"{file_index+1}: {sig.name}"
+                    sig.name = f"{file_index + 1}: {sig.name}"
 
                 signals[sig_uuid] = sig
 
@@ -2912,7 +2901,6 @@ class WithMDIArea:
         return w, plot
 
     def _add_tabular_window(self, names):
-
         if names and isinstance(names[0], str):
             signals_ = [
                 (
@@ -2975,7 +2963,7 @@ class WithMDIArea:
 
                     name = unique_names.get_unique_name(entry["name"])
 
-                    ranges[f"{file_index+1}: {name}"] = entry["ranges"]
+                    ranges[f"{file_index + 1}: {name}"] = entry["ranges"]
             else:
                 for entry in signals_:
                     if entry["origin_uuid"] != uuid:
@@ -3011,7 +2999,7 @@ class WithMDIArea:
 
             if not hasattr(self, "mdf"):
                 # MainWindow => comparison plots
-                columns = {name: f"{file_index+1}: {name}" for name in df.columns}
+                columns = {name: f"{file_index + 1}: {name}" for name in df.columns}
                 df.rename(columns=columns, inplace=True)
 
             dfs.append(df)
@@ -3313,7 +3301,6 @@ class WithMDIArea:
             signals_ = [(elem["name"], *self.mdf.whereis(elem["name"])[0]) for elem in found]
 
             if signals_:
-
                 signals = self.mdf.select(
                     signals_,
                     ignore_value2text_conversions=self.ignore_value2text_conversions,
@@ -4304,7 +4291,6 @@ class WithMDIArea:
                         pass
 
     def set_cursor(self, widget, pos):
-
         if self._busy:
             return
         else:
@@ -4641,7 +4627,7 @@ class WithMDIArea:
         result = MessageBox.question(
             self,
             "Save measurement bookmarks?",
-            "You have modified bookmarks.\n\n" "Do you want to save the changes in the measurement file?\n" "",
+            "You have modified bookmarks.\n\nDo you want to save the changes in the measurement file?\n",
         )
 
         if result == MessageBox.StandardButton.No:

--- a/src/asammdf/gui/widgets/numeric.py
+++ b/src/asammdf/gui/widgets/numeric.py
@@ -570,7 +570,6 @@ class TableModel(QtCore.QAbstractTableModel):
             return new_background_color if new_background_color != self.background_color else None
 
         elif role == QtCore.Qt.ItemDataRole.ForegroundRole:
-
             channel_ranges = self.view.ranges[signal.entry]
             raw_cell = self.backend.get_signal_value(signal, 1)
             scaled_cell = self.backend.get_signal_value(signal, 2)
@@ -675,12 +674,10 @@ class TableModel(QtCore.QAbstractTableModel):
         )
 
     def dropMimeData(self, data, action, row, column, parent):
-
         def moved_rows(data):
             rows = set()
             ds = QtCore.QDataStream(data.data("application/x-qabstractitemmodeldatalist"))
             while not ds.atEnd():
-
                 row = ds.readInt32()
                 ds.readInt32()
                 map_items = ds.readInt32()
@@ -950,7 +947,6 @@ class TableView(QtWidgets.QTableView):
             super().keyPressEvent(event)
 
     def startDrag(self, supportedActions):
-
         indexes = self.selectedIndexes()
         if not self.backend.sorting_enabled:
             mime_data = self.model().mimeData(indexes)
@@ -1489,7 +1485,6 @@ class Numeric(Ui_NumericDisplay, QtWidgets.QWidget):
         self.customContextMenuRequested.connect(self.show_menu)
 
     def show_menu(self, position):
-
         count = len(self.channels.backend)
 
         header = self.channels.columnHeader
@@ -2119,7 +2114,6 @@ class Numeric(Ui_NumericDisplay, QtWidgets.QWidget):
             and modifiers == QtCore.Qt.KeyboardModifier.NoModifier
             and self.mode == "offline"
         ):
-
             self.timestamp_slider.keyPressEvent(event)
 
         elif (

--- a/src/asammdf/gui/widgets/plot.py
+++ b/src/asammdf/gui/widgets/plot.py
@@ -3927,7 +3927,7 @@ class PlotGraphics(pg.PlotWidget):
                 bookmark = Bookmark(
                     pos=event["value"],
                     message=event["description"],
-                    title=f'{event["type"]}{label}',
+                    title=f"{event['type']}{label}",
                     color=color,
                     tool=event.get("tool", ""),
                 )
@@ -6010,7 +6010,6 @@ class PlotGraphics(pg.PlotWidget):
         self._pixmap = pixmap
 
         for idx, sig in enumerate(self.signals):
-
             if sig.individual_axis:
                 axis = self.get_axis(idx)
                 if tuple(axis.range) != tuple(sig.y_range):
@@ -6059,7 +6058,6 @@ class PlotGraphics(pg.PlotWidget):
         return y, sig_y_bottom, sig_y_top
 
     def xrange_changed_handle(self, *args, force=False):
-
         if self._can_paint:
             self.trim(force=force)
             self.update()
@@ -6067,7 +6065,6 @@ class PlotGraphics(pg.PlotWidget):
         self.zoom_changed.emit(False)
 
     def y_changed(self, *args):
-
         if len(args) == 1:
             # range manually changed by the user with the wheel or drag
             mask = args[0]

--- a/src/asammdf/gui/widgets/signal_scale.py
+++ b/src/asammdf/gui/widgets/signal_scale.py
@@ -169,7 +169,7 @@ class ScaleDialog(Ui_ScaleDialog, QtWidgets.QDialog):
             elif i == 10:
                 painter.drawText(5, x - 5, f"{100 - 10 * i}%")
             else:
-                painter.drawText(5, x + 6, f"{100-10*i}%")
+                painter.drawText(5, x + 6, f"{100 - 10 * i}%")
 
         painter.drawText(PLOT_HEIGTH + TEXT_WIDTH, 15, f"{y_top:.3f}")
         painter.drawText(

--- a/src/asammdf/gui/widgets/tabular.py
+++ b/src/asammdf/gui/widgets/tabular.py
@@ -22,7 +22,7 @@ DATA_BYTES = re.compile(r"(?P<data>.*?Data ?)Bytes(?P<cntr>_\d+)?")
 
 
 def data_length_name(match):
-    result = f'{match.group("data")}Length'
+    result = f"{match.group('data')}Length"
     if cntr := match.group("cntr"):
         result += cntr
 
@@ -99,7 +99,6 @@ class Tabular(TabularBase):
                 signals[name] = s
 
             if dropped:
-
                 signals = signals[columns]
 
             names = list(signals.columns)

--- a/src/asammdf/gui/widgets/tabular_base.py
+++ b/src/asammdf/gui/widgets/tabular_base.py
@@ -70,7 +70,6 @@ MONOSPACE_FONT = None
 
 
 class TabularTreeItem(QtWidgets.QTreeWidgetItem):
-
     DEFAULT_FLAGS = QtCore.Qt.ItemFlag.ItemIsEnabled | QtCore.Qt.ItemFlag.ItemIsSelectable
 
     def __init__(self, column_types, int_format, ranges=None, *args, **kwargs):
@@ -1355,7 +1354,7 @@ class TabularBase(Ui_TabularDisplay, QtWidgets.QWidget):
             try:
                 new_df = df.query(" ".join(filters))
             except:
-                logger.exception(f'Failed to apply filter for tabular window: {" ".join(filters)}')
+                logger.exception(f"Failed to apply filter for tabular window: {' '.join(filters)}")
                 self.query.setText(format_exc())
             else:
                 to_drop = [name for name in df.columns if name.endswith("__as__bytes")]

--- a/src/asammdf/gui/widgets/tree.py
+++ b/src/asammdf/gui/widgets/tree.py
@@ -1698,7 +1698,6 @@ class ChannelsTreeWidget(QtWidgets.QTreeWidget):
             self.setStyleSheet(SCROLLBAR_STYLE.format(font_size=size, color=color))
 
     def set_style(self):
-
         dark = (
             QtWidgets.QApplication.instance().palette().window().color().value()
             < QtWidgets.QApplication.instance().palette().windowText().color().value()

--- a/src/asammdf/gui/widgets/xy.py
+++ b/src/asammdf/gui/widgets/xy.py
@@ -103,14 +103,12 @@ class XY(Ui_XYDisplay, QtWidgets.QWidget):
         self.update_plot()
 
     def clicked(self, event):
-
         scene_pos = event.scenePos()
         pos = self.plot.plotItem.vb.mapSceneToView(scene_pos)
         x = pos.x()
         y = pos.y()
 
         if self._x is not None and self._y is not None:
-
             delta = (self._x_interp.samples - x) ** 2 + (self._y_interp.samples - y) ** 2
             idx = np.argmin(delta).flatten()[0]
 
@@ -180,7 +178,6 @@ class XY(Ui_XYDisplay, QtWidgets.QWidget):
         self.add_channels_request.emit(channels)
 
     def set_timestamp(self, stamp, emit=True, spinbox=False):
-
         if stamp is None or self._timebase is None or not len(self._timebase):
             self.marker.setData(x=[], y=[])
 
@@ -253,7 +250,6 @@ class XY(Ui_XYDisplay, QtWidgets.QWidget):
             self.set_timestamp(self._timebase[idx])
 
     def to_config(self):
-
         config = {
             "channels": [self._x.name if self._x else "", self._y.name if self._y else ""],
             "color": self._pen,
@@ -295,7 +291,6 @@ class XY(Ui_XYDisplay, QtWidgets.QWidget):
                 }
             ]
             for angle, xpos, ypos in zip(angles.tolist(), x.samples[1:].tolist(), y.samples[1:].tolist()):
-
                 transform.reset()
                 angle_rot = transform.rotate(angle)
                 my_rotated_symbol = angle_rot.map(ARROW)
@@ -322,7 +317,6 @@ class XY(Ui_XYDisplay, QtWidgets.QWidget):
             self.set_timestamp(self._timestamp)
 
     def update_timebase(self):
-
         if self._timebase is not None and len(self._timebase):
             count = len(self._timebase)
             min_, max_ = self._timebase[0], self._timebase[-1]

--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -2013,6 +2013,7 @@ class MDF:
         >>> t = np.arange(5)
         >>> s = np.ones(5)
         >>> mdf = MDF()
+        >>> mdf.configure(raise_on_multiple_occurrences=False)
         >>> for i in range(4):
         ...     sigs = [Signal(s*(i*10+j), t, name='SIG') for j in range(1,4)]
         ...     mdf.append(sigs)
@@ -2025,25 +2026,21 @@ class MDF:
                 samples=[ 1.  1.  1.  1.  1.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         <Signal SIG:
                 samples=[ 31.  31.  31.  31.  31.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         <Signal SIG:
                 samples=[ 21.  21.  21.  21.  21.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         <Signal SIG:
                 samples=[ 12.  12.  12.  12.  12.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
 
         """
@@ -2262,6 +2259,15 @@ class MDF:
 
                 .. versionadded:: 8.1.0
 
+        Returns
+        -------
+        concatenate : MDF
+            new *MDF* object with concatenated channels
+
+        Raises
+        ------
+        MdfException : if there are inconsistencies between the files
+
         Examples
         --------
         >>> conc = MDF.concatenate(
@@ -2275,15 +2281,6 @@ class MDF:
             version='4.00',
             sync=False,
         )
-
-        Returns
-        -------
-        concatenate : MDF
-            new *MDF* object with concatenated channels
-
-        Raises
-        ------
-        MdfException : if there are inconsistencies between the files
 
         """
 
@@ -2703,6 +2700,11 @@ class MDF:
 
                 .. versionadded:: 8.1.0
 
+        Returns
+        -------
+        stacked : MDF
+            new *MDF* object with stacked channels
+
         Examples
         --------
         >>> stacked = MDF.stack(
@@ -2716,11 +2718,6 @@ class MDF:
             version='4.00',
             sync=False,
         )
-
-        Returns
-        -------
-        stacked : MDF
-            new *MDF* object with stacked channels
 
         """
         if not files:
@@ -3074,6 +3071,7 @@ class MDF:
                 display_names={}
                 attachment=()>
         ]
+
         >>> resampled = mdf.resample(raster='S2')
         >>> resampled.select(['S1', 'S2'])
         [<Signal S1:
@@ -3101,6 +3099,7 @@ class MDF:
                 display_names={}
                 attachment=()>
         ]
+
         >>> resampled = mdf.resample(raster=[1.9, 2.0, 2.1])
         >>> resampled.select(['S1', 'S2'])
         [<Signal S1:
@@ -3128,6 +3127,7 @@ class MDF:
                 display_names={}
                 attachment=()>
         ]
+
         >>> resampled = mdf.resample(raster='S2', time_from_zero=True)
         >>> resampled.select(['S1', 'S2'])
         [<Signal S1:
@@ -3316,6 +3316,7 @@ class MDF:
         >>> t = np.arange(5)
         >>> s = np.ones(5)
         >>> mdf = MDF()
+        >>> mdf.configure(raise_on_multiple_occurrences=False)
         >>> for i in range(4):
         ...     sigs = [Signal(s*(i*10+j), t, name='SIG') for j in range(1,4)]
         ...     mdf.append(sigs)
@@ -3327,25 +3328,21 @@ class MDF:
                 samples=[ 1.  1.  1.  1.  1.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         , <Signal SIG:
                 samples=[ 31.  31.  31.  31.  31.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         , <Signal SIG:
                 samples=[ 21.  21.  21.  21.  21.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         , <Signal SIG:
                 samples=[ 12.  12.  12.  12.  12.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         ]
 
@@ -3618,6 +3615,7 @@ class MDF:
         >>> t = np.arange(5)
         >>> s = np.ones(5)
         >>> mdf = MDF()
+        >>> mdf.configure(raise_on_multiple_occurrences=False)
         >>> for i in range(4):
         ...     sigs = [Signal(s*(i*10+j), t, name='SIG') for j in range(1,4)]
         ...     mdf.append(sigs)
@@ -3629,25 +3627,21 @@ class MDF:
                 samples=[ 1.  1.  1.  1.  1.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         , <Signal SIG:
                 samples=[ 31.  31.  31.  31.  31.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         , <Signal SIG:
                 samples=[ 21.  21.  21.  21.  21.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         , <Signal SIG:
                 samples=[ 12.  12.  12.  12.  12.]
                 timestamps=[0 1 2 3 4]
                 unit=""
-                info=None
                 comment="">
         ]
 
@@ -5121,20 +5115,20 @@ class MDF:
 
         Examples
         --------
-        >>> "extrac CAN and LIN bus logging"
+        >>> "extract CAN and LIN bus logging"
         >>> mdf = asammdf.MDF(r'bus_logging.mf4')
         >>> databases = {
         ...     "CAN": [("file1.dbc", 0), ("file2.arxml", 2)],
         ...     "LIN": [("file3.dbc", 0)],
         ... }
-        >>> extracted = mdf.extract_bus_logging(database_files=database_files)
-        >>> ...
-        >>> "extrac just LIN bus logging"
+        >>> extracted = mdf.extract_bus_logging(database_files=databases)
+
+        >>> "extract just LIN bus logging"
         >>> mdf = asammdf.MDF(r'bus_logging.mf4')
         >>> databases = {
         ...     "LIN": [("file3.dbc", 0)],
         ... }
-        >>> extracted = mdf.extract_bus_logging(database_files=database_files)
+        >>> extracted = mdf.extract_bus_logging(database_files=databases)
 
         """
         if ignore_invalid_signals is not None:

--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -875,7 +875,7 @@ class MDF:
             case the original file version is used
         include_ends : bool
             include the *start* and *stop* timestamps after cutting the signal.
-            If *start* and *stop* are found in the original timestamps, then
+            If *start* and *stop* are not found in the original timestamps, then
             the new samples will be computed using interpolation. Default *True*
         time_from_zero : bool
             start time stamps from 0s in the cut measurement

--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -183,7 +183,6 @@ def master_using_raster(mdf: MDF_v2_v3_v4, raster: RasterType, endpoint: bool = 
             group = mdf.groups[group_index]
             cycles_nr = group.channel_group.cycles_nr
             if cycles_nr:
-
                 master_min = mdf.get_master(group_index, record_offset=0, record_count=1)
                 if len(master_min):
                     t_min.append(master_min[0])
@@ -415,7 +414,7 @@ class MDF:
                 self._mdf = mdf_v4.MDF4(version=version, **kwargs)
             else:
                 message = (
-                    f'"{version}" is not a supported MDF file version; ' f"Supported versions are {SUPPORTED_VERSIONS}"
+                    f'"{version}" is not a supported MDF file version; Supported versions are {SUPPORTED_VERSIONS}'
                 )
                 raise MdfException(message)
 
@@ -1301,7 +1300,7 @@ class MDF:
         fmt = fmt.lower()
 
         if fmt != "pandas" and filename is None and self.name is None:
-            message = "Must specify filename for export" "if MDF was created without a file name"
+            message = "Must specify filename for exportif MDF was created without a file name"
             logger.warning(message)
             return
 
@@ -1732,7 +1731,7 @@ class MDF:
                     if progress is not None and progress.stop:
                         return TERMINATED
 
-                    message = f"Exporting group {i+1} of {gp_count}"
+                    message = f"Exporting group {i + 1} of {gp_count}"
                     logger.info(message)
 
                     if len(virtual_group.groups) == 1:
@@ -2031,7 +2030,7 @@ class MDF:
                 write_parquet(df, filename)
 
         else:
-            message = 'Unsupported export type "{}". ' 'Please select "csv", "excel", "hdf5", "mat" or "pandas"'
+            message = 'Unsupported export type "{}". Please select "csv", "excel", "hdf5", "mat" or "pandas"'
             message.format(fmt)
             logger.warning(message)
 
@@ -2824,7 +2823,7 @@ class MDF:
 
             if progress is not None:
                 progress.signals.setLabelText.emit(
-                    f"Stacking file {mdf_index+1} of {files_nr}\n" f"{mdf.original_name.name}"
+                    f"Stacking file {mdf_index + 1} of {files_nr}\n{mdf.original_name.name}"
                 )
 
             if mdf_index == 0:
@@ -2881,9 +2880,9 @@ class MDF:
 
                 if dg_cntr is not None:
                     for index in range(dg_cntr, len(stacked.groups)):
-                        stacked.groups[index].channel_group.comment = (
-                            f'stacked from channel group {i} of "{mdf.name.parent}"'
-                        )
+                        stacked.groups[
+                            index
+                        ].channel_group.comment = f'stacked from channel group {i} of "{mdf.name.parent}"'
 
             if progress is not None:
                 if callable(progress):
@@ -5067,7 +5066,6 @@ class MDF:
             return pl.DataFrame(df)
 
         else:
-
             strings, nonstrings = {}, {}
 
             for col, series in df.items():
@@ -5588,7 +5586,7 @@ class MDF:
             out = tmp
 
         if not out.groups:
-            logger.warning(f'No CAN signals could be extracted from "{self.name}". The' "output file will be empty.")
+            logger.warning(f'No CAN signals could be extracted from "{self.name}". Theoutput file will be empty.')
 
         return out
 
@@ -5840,7 +5838,7 @@ class MDF:
         }
 
         if not out.groups:
-            logger.warning(f'No LIN signals could be extracted from "{self.name}". The' "output file will be empty.")
+            logger.warning(f'No LIN signals could be extracted from "{self.name}". Theoutput file will be empty.')
 
         return out
 
@@ -6429,15 +6427,15 @@ class MDF:
 
                 elif row["type"] == "FLEXRAY":
                     if row["Event Type"] == "FlexRay Frame":
-                        frame_flags = f'{row["FrameFlags"]:x}'
-                        controller_flags = f'{row["ControllerFlags"]:x}'
+                        frame_flags = f"{row['FrameFlags']:x}"
+                        controller_flags = f"{row['ControllerFlags']:x}"
                         data = row["Data Bytes"]
-                        header_crc = f'{row["Header CRC"]:x}'
-                        data_length = f'{row["Data Length"]:x}'
-                        payload_length = f'{row["Payload Length"]:x}'
-                        bus = f'{row["Bus"] + 1:x}'
-                        slot = f'{row["ID"]:x}'
-                        cycle = f'{row["Cycle"]:x}'
+                        header_crc = f"{row['Header CRC']:x}"
+                        data_length = f"{row['Data Length']:x}"
+                        payload_length = f"{row['Payload Length']:x}"
+                        bus = f"{row['Bus'] + 1:x}"
+                        slot = f"{row['ID']:x}"
+                        cycle = f"{row['Cycle']:x}"
                         dir = row["Direction"]
                         t = row["timestamps"]
 
@@ -6446,13 +6444,13 @@ class MDF:
                         )
 
                     elif row["Event Type"] == "FlexRay NullFrame":
-                        frame_flags = f'{row["FrameFlags"]:x}'
-                        controller_flags = f'{row["ControllerFlags"]:x}'
-                        header_crc = f'{row["Header CRC"]:x}'
-                        payload_length = f'{row["Payload Length"]:x}'
-                        bus = f'{row["Bus"] + 1:x}'
-                        slot = f'{row["ID"]:x}'
-                        cycle = f'{row["Cycle"]:x}'
+                        frame_flags = f"{row['FrameFlags']:x}"
+                        controller_flags = f"{row['ControllerFlags']:x}"
+                        header_crc = f"{row['Header CRC']:x}"
+                        payload_length = f"{row['Payload Length']:x}"
+                        bus = f"{row['Bus'] + 1:x}"
+                        slot = f"{row['ID']:x}"
+                        cycle = f"{row['Cycle']:x}"
                         dir = row["Direction"]
                         t = row["timestamps"]
 

--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -2875,12 +2875,12 @@ class MDF:
             do not yield master channels; default *True*
         copy_master : bool
             copy master for each yielded channel *True*
-        raw : bool
+        raw : bool | dict[str, bool]
             return raw channels instead of converted; default *False*
 
             .. versionchanged:: 8.0.0
 
-                provide individual raw mode based on a dict. If the parameters is given
+                provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
 
@@ -2935,14 +2935,14 @@ class MDF:
 
             .. versionadded:: 5.21.0
 
-        raw (False) : bool
-            the dataframe will contain the raw channel values
+        raw : bool | dict[str, bool]
+            the DataFrame will contain the raw channel values; default *False*
 
             .. versionadded:: 5.21.0
 
             .. versionchanged:: 8.0.0
 
-                provide individual raw mode based on a dict. If the parameters is given
+                provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
 
@@ -3285,7 +3285,7 @@ class MDF:
 
             .. versionchanged:: 8.0.0
 
-                provide individual raw mode based on a dict. If the parameters is given
+                provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
 
@@ -3584,7 +3584,7 @@ class MDF:
 
             .. versionchanged:: 8.0.0
 
-                provide individual raw mode based on a dict. If the parameters is given
+                provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
 
@@ -4141,14 +4141,14 @@ class MDF:
             reduce memory usage by converting all float columns to float32 and
             searching for minimum dtype that can reprezent the values found
             in integer columns; default *False*
-        raw (False) : bool | dict[str, bool]
-            the dataframe will contain the raw channel values
+        raw : bool | dict[str, bool]
+            the DataFrame will contain the raw channel values; default *False*
 
             .. versionadded:: 5.7.0
 
             .. versionchanged:: 8.0.0
 
-                provide individual raw mode based on a dict. If the parameters is given
+                provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
 
@@ -4280,12 +4280,12 @@ class MDF:
             reduce memory usage by converting all float columns to float32 and
             searching for minimum dtype that can reprezent the values found
             in integer columns; default *False*
-        raw (False) : bool
-            the columns will contain the raw values
+        raw : bool | dict[str, bool]
+            the columns will contain the raw values; default *False*
 
             .. versionchanged:: 8.0.0
 
-                provide individual raw mode based on a dict. If the parameters is given
+                provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
 
@@ -4690,14 +4690,14 @@ class MDF:
             reduce memory usage by converting all float columns to float32 and
             searching for minimum dtype that can reprezent the values found
             in integer columns; default *False*
-        raw (False) : bool
-            the columns will contain the raw values
+        raw : bool | dict[str, bool]
+            the columns will contain the raw values; default *False*
 
             .. versionadded:: 5.7.0
 
             .. versionchanged:: 8.0.0
 
-                provide individual raw mode based on a dict. If the parameters is given
+                provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
 

--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -1300,7 +1300,7 @@ class MDF:
         fmt = fmt.lower()
 
         if fmt != "pandas" and filename is None and self.name is None:
-            message = "Must specify filename for exportif MDF was created without a file name"
+            message = "Must specify filename for export if MDF was created without a file name"
             logger.warning(message)
             return
 
@@ -5586,7 +5586,7 @@ class MDF:
             out = tmp
 
         if not out.groups:
-            logger.warning(f'No CAN signals could be extracted from "{self.name}". Theoutput file will be empty.')
+            logger.warning(f'No CAN signals could be extracted from "{self.name}". The output file will be empty.')
 
         return out
 
@@ -5838,7 +5838,7 @@ class MDF:
         }
 
         if not out.groups:
-            logger.warning(f'No LIN signals could be extracted from "{self.name}". Theoutput file will be empty.')
+            logger.warning(f'No LIN signals could be extracted from "{self.name}". The output file will be empty.')
 
         return out
 

--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -166,7 +166,7 @@ class MDF:
     ----------
     name : string | BytesIO | zipfile.ZipFile | bz2.BZ2File | gzip.GzipFile
         mdf file name (if provided it must be a real file name), file-like object or
-        compressed file opened as Python object
+        compressed file opened as a Python object
 
         .. versionchanged:: 6.2.0
 
@@ -179,29 +179,29 @@ class MDF:
         from a file the version is set to file version
 
     channels (None) : iterable
-        channel names that will used for selective loading. This can dramatically
-        improve the file loading time. Default None -> load all channels
+        channel names that will be used for selective loading. This can dramatically
+        improve the file loading time. Default *None* -> load all channels
 
         .. versionadded:: 6.1.0
 
-        .. versionchanged:: 6.3.0 make the default None
+        .. versionchanged:: 6.3.0 make the default *None*
 
     use_display_names (\*\*kwargs) : bool
-        keyword only argument: for MDF4 files parse the XML channel comment to
+        keyword-only argument: for MDF v4 files, parse the XML channel comment to
         search for the display name; XML parsing is quite expensive so setting
         this to *False* can decrease the loading times very much; default
         *True*
     remove_source_from_channel_names (\*\*kwargs) : bool
         remove source from channel names ("Speed\XCP3" -> "Speed")
     copy_on_get (\*\*kwargs) : bool
-        copy arrays in the get method; default *True*
+        copy arrays in the `get` method; default *True*
     expand_zippedfile (\*\*kwargs) : bool
         only for bz2.BZ2File and gzip.GzipFile, load the file content into a
         BytesIO before parsing (avoids the huge performance penalty of doing
         random reads from the zipped file); default *True*
     raise_on_multiple_occurrences (\*\*kwargs) : bool
-        raise exception when there are multiple channel occurrences in the file and
-        the `get` call is ambiguous; default True
+        raise MdfException when there are multiple channel occurrences in the file and
+        the `get` call is ambiguous; default *True*
 
         .. versionadded:: 7.0.0
 
@@ -211,7 +211,7 @@ class MDF:
         .. versionadded:: 7.0.0
 
     process_bus_logging (\*\*kwargs) : bool
-        controls if the bus processing of MDF v4 files is done when the file is loaded. Default True
+        controls if the bus processing of MDF v4 files is done when the file is loaded. Default *True*
 
         .. versionadded:: 8.0.0
 
@@ -651,9 +651,10 @@ class MDF:
         temporary_folder: str | None = None,
         fill_0_for_missing_computation_channels: bool | None = None,
     ) -> None:
-        """configure MDF parameters
+        """Configure *MDF* parameters.
 
         The default values for the options are the following:
+
         * read_fragment_size = 0
         * write_fragment_size = 4MB
         * use_display_names = False
@@ -679,7 +680,7 @@ class MDF:
         use_display_names : bool
             search for display name in the Channel XML comment
         single_bit_uint_as_bool : bool
-            return single bit channels are np.bool arrays
+            return single bit channels as np.bool arrays
         integer_interpolation : int
             interpolation mode for integer channels:
 
@@ -704,8 +705,8 @@ class MDF:
                 .. versionadded:: 6.2.0
 
         raise_on_multiple_occurrences : bool
-            raise exception when there are multiple channel occurrences in the file and
-            the `get` call is ambiguous; default True
+            raise MdfException when there are multiple channel occurrences in the file and
+            the `get` call is ambiguous; default *True*
 
             .. versionadded:: 6.2.0
 
@@ -721,7 +722,7 @@ class MDF:
 
         fill_0_for_missing_computation_channels : bool
             when a channel required by a computed channel is missing, then fill with 0 values.
-            If false then the computation will fail and the computed channel will be marked as not existing.
+            If *False* then the computation will fail and the computed channel will be marked as not existing.
 
             .. versionadded:: 7.1.0
         """
@@ -768,7 +769,7 @@ class MDF:
             self._raise_on_multiple_occurrences = bool(raise_on_multiple_occurrences)
 
     def convert(self, version: str, progress=None) -> MDF:
-        """convert *MDF* to other version
+        """Convert *MDF* to other version.
 
         Parameters
         ----------
@@ -851,7 +852,7 @@ class MDF:
         time_from_zero: bool = False,
         progress=None,
     ) -> MDF:
-        """cut *MDF* file. *start* and *stop* limits are absolute values
+        """Cut *MDF* file. *start* and *stop* limits are absolute values
         or values relative to the first timestamp depending on the *whence*
         argument.
 
@@ -878,12 +879,12 @@ class MDF:
             If *start* and *stop* are not found in the original timestamps, then
             the new samples will be computed using interpolation. Default *True*
         time_from_zero : bool
-            start time stamps from 0s in the cut measurement
+            start timestamps from 0s in the cut measurement
 
         Returns
         -------
         out : MDF
-            new MDF object
+            new *MDF* object
 
         """
 
@@ -1114,10 +1115,10 @@ class MDF:
         progress=None,
         **kwargs,
     ) -> None:
-        r"""export *MDF* to other formats. The *MDF* file name is used is
+        r"""Export *MDF* to other formats. The *MDF* file name is used if
         available, else the *filename* argument must be provided.
 
-        The *pandas* export option was removed. you should use the method
+        The *pandas* export option was removed. You should use the method
         *to_dataframe* instead.
 
         Parameters
@@ -1167,7 +1168,7 @@ class MDF:
               prefixed with the parent channel.
             * `reduce_memory_usage` : bool
               reduce memory usage by converting all float columns to float32 and
-              searching for minimum dtype that can reprezent the values found
+              searching for minimum dtype that can represent the values found
               in integer columns; default *False*
             * `compression` : str
               compression to be used
@@ -1181,13 +1182,13 @@ class MDF:
                 added LZ4 compression after changing to pyarrow
 
             * `time_as_date` (False) : bool
-              export time as local timezone datetimee; only valid for CSV export
+              export time as local timezone datetime; only valid for CSV export
 
               .. versionadded:: 5.8.0
 
             * `ignore_value2text_conversions` (False) : bool
               valid only for the channels that have value to text conversions and
-              if *raw=False*. If this is True then the raw numeric values will be
+              if *raw=False*. If this is *True* then the raw numeric values will be
               used, and the conversion will not be applied.
 
               .. versionadded:: 5.8.0
@@ -1983,8 +1984,8 @@ class MDF:
             logger.warning(message)
 
     def filter(self, channels: ChannelsType, version: str | None = None, progress=None) -> MDF:
-        """return new *MDF* object that contains only the channels listed in
-        *channels* argument
+        """Return new *MDF* object that contains only the channels listed in the
+        *channels* argument.
 
         Parameters
         ----------
@@ -2165,12 +2166,12 @@ class MDF:
         samples_only: bool = False,
         raw: bool = False,
     ) -> Iterator[Signal] | Iterator[tuple[NDArray[Any], NDArray[Any] | None]]:
-        """iterator over a channel
+        """Iterator over a channel.
 
         This is usefull in case of large files with a small number of channels.
 
         If the *raster* keyword argument is not *None* the output is
-        interpolated accordingly
+        interpolated accordingly.
 
         Parameters
         ----------
@@ -2184,10 +2185,10 @@ class MDF:
             time raster in seconds
         samples_only : bool
             if *True* return only the channel samples as numpy array; if
-                *False* return a *Signal* object
+            *False* return a *Signal* object
         raw : bool
-            return channel samples without appling the conversion rule; default
-            `False`
+            return channel samples without applying the conversion rule; default
+            *False*
 
         """
 
@@ -2218,11 +2219,10 @@ class MDF:
         progress=None,
         **kwargs,
     ) -> MDF:
-        """concatenates several files. The files
-        must have the same internal structure (same number of groups, and same
-        channels in each group).
+        """Concatenates several files. The files must have the same internal
+        structure (same number of groups, and same channels in each group).
 
-        The order of the input files is always preserved, only the samples timestamps are influenced
+        The order of the input files is always preserved, only the samples' timestamps are influenced
         by the ``sync`` argument.
 
         Parameters
@@ -2239,14 +2239,14 @@ class MDF:
             merged file version
         sync : bool
             sync the files based on the start of measurement, default *True*. The order of the
-            input files is preserved, only the samples timestamps are influenced by this
+            input files is preserved, only the samples' timestamps are influenced by this
             argument
         add_samples_origin : bool
             option to create a new "__samples_origin" channel that will hold
             the index of the measurement from where each timestamp originated
         direct_timestamp_continuation (False) : bool
-            the time stamps from the next file will be added right after the last
-            time stamp from the previous file; default False
+            the timestamps from the next file will be added right after the last
+            timestamp from the previous file; default *False*
 
             ..versionadded:: 6.0.0
 
@@ -2255,7 +2255,7 @@ class MDF:
             use_display_names (False) : bool
 
             process_bus_logging (True) : bool
-                controls if the bus processing of MDF v4 files is done when the file is loaded. Default True
+                controls if the bus processing of MDF v4 files is done when the file is loaded. Default *True*
 
                 .. versionadded:: 8.1.0
 
@@ -2675,7 +2675,7 @@ class MDF:
         progress=None,
         **kwargs,
     ) -> MDF:
-        """stack several files and return the stacked *MDF* object
+        """Stack several files and return the stacked *MDF* object.
 
         Parameters
         ----------
@@ -2696,7 +2696,7 @@ class MDF:
             use_display_names (False) : bool
 
             process_bus_logging (True) : bool
-                controls if the bus processing of MDF v4 files is done when the file is loaded. Default True
+                controls if the bus processing of MDF v4 files is done when the file is loaded. Default *True*
 
                 .. versionadded:: 8.1.0
 
@@ -2867,14 +2867,14 @@ class MDF:
         copy_master: bool = True,
         raw: bool | dict[str, bool] = False,
     ) -> Iterator[Signal]:
-        """generator that yields a *Signal* for each non-master channel
+        """Generator that yields a *Signal* for each non-master channel.
 
         Parameters
         ----------
         skip_master : bool
             do not yield master channels; default *True*
         copy_master : bool
-            copy master for each yielded channel *True*
+            copy master for each yielded channel; default *True*
         raw : bool | dict[str, bool]
             return raw channels instead of converted; default *False*
 
@@ -2883,8 +2883,6 @@ class MDF:
                 provide individual raw mode based on a dict. If the argument is given
                 as dict then it must contain the key ``__default__`` with the default raw value. The dict keys
                 are the channel names and the values are the boolean raw values for each channel.
-
-
         """
 
         if isinstance(raw, dict):
@@ -2915,11 +2913,10 @@ class MDF:
         ignore_value2text_conversions: bool = False,
         only_basenames: bool = False,
     ) -> Iterator[pd.DataFrame]:
-        """generator that yields channel groups as pandas DataFrames. If there
+        """Generator that yields channel groups as pandas DataFrames. If there
         are multiple occurrences for the same channel name inside a channel
         group, then a counter will be used to make the names unique
-        (<original_name>_<counter>)
-
+        (<original_name>_<counter>).
 
         Parameters
         ----------
@@ -2930,7 +2927,7 @@ class MDF:
 
         reduce_memory_usage : bool
             reduce memory usage by converting all float columns to float32 and
-            searching for minimum dtype that can reprezent the values found
+            searching for minimum dtype that can represent the values found
             in integer columns; default *False*
 
             .. versionadded:: 5.21.0
@@ -2948,7 +2945,7 @@ class MDF:
 
         ignore_value2text_conversions (False) : bool
             valid only for the channels that have value to text conversions and
-            if *raw=False*. If this is True then the raw numeric values will be
+            if *raw=False*. If this is *True* then the raw numeric values will be
             used, and the conversion will not be applied.
 
             .. versionadded:: 5.21.0
@@ -2977,7 +2974,7 @@ class MDF:
             new raster that can be
 
             * a float step value
-            * a channel name who's timestamps will be used as raster (starting with asammdf 5.5.0)
+            * a channel name whose timestamps will be used as raster (starting with asammdf 5.5.0)
             * an array (starting with asammdf 5.5.0)
 
             see `resample` for examples of using this argument
@@ -3008,8 +3005,8 @@ class MDF:
         time_from_zero: bool = False,
         progress=None,
     ) -> MDF:
-        """resample all channels using the given raster. See *configure* to select
-        the interpolation method for interger channels
+        """Resample all channels using the given raster. See *configure* to select
+        the interpolation method for integer channels.
 
         Parameters
         ----------
@@ -3017,7 +3014,7 @@ class MDF:
             new raster that can be
 
             * a float step value
-            * a channel name who's timestamps will be used as raster (starting with asammdf 5.5.0)
+            * a channel name whose timestamps will be used as raster (starting with asammdf 5.5.0)
             * an array (starting with asammdf 5.5.0)
 
         version : str
@@ -3026,7 +3023,7 @@ class MDF:
             in this case the original file version is used
 
         time_from_zero : bool
-            start time stamps from 0s in the cut measurement
+            start timestamps from 0s in the resampled measurement
 
         Returns
         -------
@@ -3262,10 +3259,10 @@ class MDF:
         record_count: int | None = None,
         validate: bool = False,
     ) -> list[Signal]:
-        """retrieve the channels listed in *channels* argument as *Signal*
-        objects
+        """Retrieve the channels listed in the *channels* argument as *Signal*
+        objects.
 
-        .. note:: the *dataframe* argument was removed in version 5.8.0
+        .. note:: the *dataframe* argument was removed in version 5.8.0,
                   use the ``to_dataframe`` method instead
 
         Parameters
@@ -3294,7 +3291,7 @@ class MDF:
             use a shared array for channels of the same channel group; default *True*
         ignore_value2text_conversions (False) : bool
             valid only for the channels that have value to text conversions and
-            if *raw=False*. If this is True then the raw numeric values will be
+            if *raw=False*. If this is *True* then the raw numeric values will be
             used, and the conversion will not be applied.
 
             .. versionchanged:: 5.8.0
@@ -3561,10 +3558,10 @@ class MDF:
         record_count: int | None = None,
         validate: bool = False,
     ) -> list[Signal]:
-        """retrieve the channels listed in *channels* argument as *Signal*
-        objects
+        """Retrieve the channels listed in the *channels* argument as *Signal*
+        objects.
 
-        .. note:: the *dataframe* argument was removed in version 5.8.0
+        .. note:: the *dataframe* argument was removed in version 5.8.0,
                   use the ``to_dataframe`` method instead
 
         Parameters
@@ -3593,7 +3590,7 @@ class MDF:
             use a shared array for channels of the same channel group; default *True*
         ignore_value2text_conversions (False) : bool
             valid only for the channels that have value to text conversions and
-            if *raw=False*. If this is True then the raw numeric values will be
+            if *raw=False*. If this is *True* then the raw numeric values will be
             used, and the conversion will not be applied.
 
             .. versionchanged:: 5.8.0
@@ -3771,21 +3768,21 @@ class MDF:
 
     @staticmethod
     def scramble(name: StrPathType, skip_attachments: bool = False, progress=None, **kwargs) -> Path:
-        """scramble text blocks and keep original file structure
+        """Scramble text blocks and keep original file structure.
 
         Parameters
         ----------
         name : str | pathlib.Path
             file name
         skip_attachments : bool
-            skip scrambling of attachments data if True
+            skip scrambling of attachments data if *True*
 
             .. versionadded:: 5.9.0
 
         Returns
         -------
         name : pathlib.Path
-            scrambled file name
+            name of scrambled file
 
         """
 
@@ -4075,7 +4072,7 @@ class MDF:
 
     @staticmethod
     def _fallback_scramble_mf4(name: StrOrBytesPathType) -> dict[int, bytes]:
-        """scramble text blocks and keep original file structure
+        """Scramble text blocks and keep original file structure.
 
         Parameters
         ----------
@@ -4085,7 +4082,7 @@ class MDF:
         Returns
         -------
         name : pathlib.Path
-            scrambled file name
+            name of scrambled file
 
         """
 
@@ -4127,9 +4124,9 @@ class MDF:
         ignore_value2text_conversions: bool = False,
         only_basenames: bool = False,
     ) -> pd.DataFrame:
-        """get channel group as pandas DataFrames. If there are multiple
+        """Get channel group as pandas DataFrames. If there are multiple
         occurrences for the same channel name, then a counter will be used to
-        make the names unique (<original_name>_<counter>)
+        make the names unique (<original_name>_<counter>).
 
         Parameters
         ----------
@@ -4139,7 +4136,7 @@ class MDF:
             use display name instead of standard channel name, if available.
         reduce_memory_usage : bool
             reduce memory usage by converting all float columns to float32 and
-            searching for minimum dtype that can reprezent the values found
+            searching for minimum dtype that can represent the values found
             in integer columns; default *False*
         raw : bool | dict[str, bool]
             the DataFrame will contain the raw channel values; default *False*
@@ -4154,7 +4151,7 @@ class MDF:
 
         ignore_value2text_conversions (False) : bool
             valid only for the channels that have value to text conversions and
-            if *raw=False*. If this is True then the raw numeric values will be
+            if *raw=False*. If this is *True* then the raw numeric values will be
             used, and the conversion will not be applied.
 
             .. versionadded:: 5.8.0
@@ -4186,7 +4183,7 @@ class MDF:
             new raster that can be
 
             * a float step value
-            * a channel name who's timestamps will be used as raster (starting with asammdf 5.5.0)
+            * a channel name whose timestamps will be used as raster (starting with asammdf 5.5.0)
             * an array (starting with asammdf 5.5.0)
 
             see `resample` for examples of using this argument
@@ -4236,15 +4233,15 @@ class MDF:
         numeric_1D_only: bool = False,
         progress=None,
     ) -> Iterator[pd.DataFrame]:
-        """generator that yields pandas DataFrame's that should not exceed
-        200MB of RAM
+        """Generator that yields pandas DataFrames that should not exceed
+        200MB of RAM.
 
         .. versionadded:: 5.15.0
 
         Parameters
         ----------
         channels : list
-            list of items to be filtered (default None); each item can be :
+            list of items to be filtered (default *None*); each item can be :
 
                 * a channel name string
                 * (channel name, group index, channel index) list or tuple
@@ -4255,7 +4252,7 @@ class MDF:
             new raster that can be
 
             * a float step value
-            * a channel name who's timestamps will be used as raster (starting with asammdf 5.5.0)
+            * a channel name whose timestamps will be used as raster (starting with asammdf 5.5.0)
             * an array (starting with asammdf 5.5.0)
 
             see `resample` for examples of using this argument
@@ -4273,12 +4270,12 @@ class MDF:
             only the component channels are saved, and their names will be
             prefixed with the parent channel.
         time_as_date : bool
-            the dataframe index will contain the datetime timestamps
+            the DataFrame index will contain the datetime timestamps
             according to the measurement start time; default *False*. If
             *True* then the argument ``time_from_zero`` will be ignored.
         reduce_memory_usage : bool
             reduce memory usage by converting all float columns to float32 and
-            searching for minimum dtype that can reprezent the values found
+            searching for minimum dtype that can represent the values found
             in integer columns; default *False*
         raw : bool | dict[str, bool]
             the columns will contain the raw values; default *False*
@@ -4291,31 +4288,31 @@ class MDF:
 
         ignore_value2text_conversions (False) : bool
             valid only for the channels that have value to text conversions and
-            if *raw=False*. If this is True then the raw numeric values will be
+            if *raw=False*. If this is *True* then the raw numeric values will be
             used, and the conversion will not be applied.
         use_interpolation (True) : bool
-            option to perform interpolations when multiple timestamp raster are
-            present. If *False* then dataframe columns will be automatically
-            filled with NaN's were the dataframe index values are not found in
+            option to perform interpolations when multiple timestamp rasters are
+            present. If *False* then DataFrame columns will be automatically
+            filled with NaNs were the DataFrame index values are not found in
             the current column's timestamps
         only_basenames (False) : bool
-            use jsut the field names, without prefix, for structures and channel
+            use just the field names, without prefix, for structures and channel
             arrays
         interpolate_outwards_with_nan : bool
             use NaN values for the samples that lie outside of the original
             signal's timestamps
         chunk_ram_size : int
-            desired data frame RAM usage in bytes; default 200 MB
+            desired DataFrame RAM usage in bytes; default 200 MB
         numeric_1D_only (False) : bool
             only keep the 1D-columns that have numeric values
 
             .. versionadded:: 7.0.0
 
 
-        Returns
-        -------
+        Yields
+        ------
         dataframe : pandas.DataFrame
-            yields pandas DataFrame's that should not exceed 200MB of RAM
+            pandas DataFrames that should not exceed 200MB of RAM
 
         """
 
@@ -4649,12 +4646,12 @@ class MDF:
         progress=None,
         use_polars=False,
     ) -> pd.DataFrame:
-        """generate pandas DataFrame
+        """Generate pandas DataFrame.
 
         Parameters
         ----------
         channels : list
-            list of items to be filtered (default None); each item can be :
+            list of items to be filtered (default *None*); each item can be :
 
                 * a channel name string
                 * (channel name, group index, channel index) list or tuple
@@ -4665,7 +4662,7 @@ class MDF:
             new raster that can be
 
             * a float step value
-            * a channel name who's timestamps will be used as raster (starting with asammdf 5.5.0)
+            * a channel name whose timestamps will be used as raster (starting with asammdf 5.5.0)
             * an array (starting with asammdf 5.5.0)
 
             see `resample` for examples of using this argument
@@ -4683,12 +4680,12 @@ class MDF:
             only the component channels are saved, and their names will be
             prefixed with the parent channel.
         time_as_date : bool
-            the dataframe index will contain the datetime timestamps
+            the DataFrame index will contain the datetime timestamps
             according to the measurement start time; default *False*. If
             *True* then the argument ``time_from_zero`` will be ignored.
         reduce_memory_usage : bool
             reduce memory usage by converting all float columns to float32 and
-            searching for minimum dtype that can reprezent the values found
+            searching for minimum dtype that can represent the values found
             in integer columns; default *False*
         raw : bool | dict[str, bool]
             the columns will contain the raw values; default *False*
@@ -4703,15 +4700,15 @@ class MDF:
 
         ignore_value2text_conversions (False) : bool
             valid only for the channels that have value to text conversions and
-            if *raw=False*. If this is True then the raw numeric values will be
+            if *raw=False*. If this is *True* then the raw numeric values will be
             used, and the conversion will not be applied.
 
             .. versionadded:: 5.8.0
 
         use_interpolation (True) : bool
-            option to perform interpolations when multiple timestamp raster are
-            present. If *False* then dataframe columns will be automatically
-            filled with NaN's were the dataframe index values are not found in
+            option to perform interpolations when multiple timestamp rasters are
+            present. If *False* then DataFrame columns will be automatically
+            filled with NaNs were the DataFrame index values are not found in
             the current column's timestamps
 
             .. versionadded:: 5.11.0
@@ -5060,7 +5057,7 @@ class MDF:
         prefix: str = "",
         progress=None,
     ) -> MDF:
-        """extract all possible CAN signal using the provided databases.
+        """Extract all possible CAN signals using the provided databases.
 
         Changed in version 6.0.0 from `extract_can_logging`
 
@@ -5069,13 +5066,13 @@ class MDF:
         database_files : dict
             each key will contain an iterable of database files for that bus type. The
             supported bus types are "CAN", "LIN". The iterables will contain the
-            (databases, valid bus) pairs. The database can be a  str, pathlib.Path or canamtrix.CanMatrix object.
+            (databases, valid bus) pairs. The database can be a str, pathlib.Path or canmatrix.CanMatrix object.
             The valid bus is an integer specifying for which bus channel the database
             can be applied; 0 means any bus channel.
 
             .. versionchanged:: 6.0.0 added canmatrix.CanMatrix type
 
-            .. versionchanged:: 6.3.0 added bus channel fileter
+            .. versionchanged:: 6.3.0 added bus channel filter
 
         version (None) : str
             output file version
@@ -5111,7 +5108,7 @@ class MDF:
         Returns
         -------
         mdf : MDF
-            new MDF file that contains the succesfully extracted signals
+            new *MDF* file that contains the succesfully extracted signals
 
         Examples
         --------
@@ -5797,7 +5794,7 @@ class MDF:
 
     @property
     def start_time(self) -> datetime:
-        """getter and setter the measurement start timestamp
+        """Getter and setter of the measurement start timestamp.
 
         Returns
         -------
@@ -5821,7 +5818,7 @@ class MDF:
         version: str | None = None,
         progress=None,
     ) -> MDF:
-        """convert *MDF* to other version
+        """Convert *MDF* to other version.
 
         .. versionadded:: 5.22.0
 
@@ -5935,18 +5932,18 @@ class MDF:
         source_path: str | None = None,
         acq_name: str | None = None,
     ) -> tuple[tuple[int, int], ...]:
-        """get occurrences of channel name in the file
+        """Get occurrences of channel name in the file.
 
         Parameters
         ----------
         channel : str
             channel name string
         source_name : str, optional
-            filter occurrences on source name, by default None
+            filter occurrences on source name, default *None*
         source_path : str, optional
-            filter occurrences on source path, by default None
+            filter occurrences on source path, default *None*
         acq_name : str, optional
-            filter occurrences on channel group acquisition name, by default None
+            filter occurrences on channel group acquisition name, default *None*
 
             .. versionadded:: 6.0.0
 
@@ -5979,7 +5976,7 @@ class MDF:
         mode: Literal["plain", "regex", "wildcard"] | SearchMode = SearchMode.plain,
         case_insensitive: bool = False,
     ) -> list[str]:
-        """search channels
+        """Search channels.
 
         .. versionadded:: 7.0.0
 
@@ -5994,7 +5991,7 @@ class MDF:
                 * `regex` : regular expression based search
                 * `wildcard` : wildcard based search
         case_insensitive : bool, optional
-            case sensitivity for the channel name search, by default False
+            case sensitivity for the channel name search, default *False*
 
         Returns
         -------

--- a/src/asammdf/signal.py
+++ b/src/asammdf/signal.py
@@ -34,8 +34,7 @@ logger = logging.getLogger("asammdf")
 
 
 class Signal:
-    """
-    The *Signal* represents a channel described by it's samples and timestamps.
+    """The *Signal* represents a channel described by its samples and timestamps.
     It can perform arithmetic operations against other *Signal* or numeric types.
     The operations are computed in respect to the timestamps (time correct).
     The non-float signals are not interpolated, instead the last value relative
@@ -53,16 +52,16 @@ class Signal:
     name : str
         signal name
     conversion : dict | channel conversion block
-        dict that contains extra conversion information about the signal ,
+        dict that contains extra conversion information about the signal;
         default *None*
     comment : str
-        signal comment, default ''
+        signal comment; default ''
     raw : bool
         signal samples are raw values, with no physical conversion applied
     master_metadata : list
         master name and sync type
     display_names : dict
-        display names used by mdf version 3
+        display names used by MDF version 3
     attachment : bytes, name
         channel attachment and name from MDF version 4
     source : Source
@@ -70,7 +69,7 @@ class Signal:
     bit_count : int
         bit count; useful for integer channels
     invalidation_bits : numpy.array | None
-        channel invalidation bits, default *None*
+        channel invalidation bits; default *None*
     encoding : str | None
         encoding for string signals; default *None*
     flags : Signal.Flags
@@ -223,8 +222,8 @@ class Signal:
 """
 
     def plot(self, validate: bool = True, index_only: bool = False) -> None:
-        """plot Signal samples. Pyqtgraph is used if it is available; in this
-        case see the GUI plot documentation to see the available commands
+        """Plot Signal samples. Pyqtgraph is used if it is available; in this
+        case see the GUI plot documentation to see the available commands.
 
         Parameters
         ----------
@@ -439,8 +438,7 @@ class Signal:
             FloatInterpolationModeType | FloatInterpolation
         ) = FloatInterpolation.LINEAR_INTERPOLATION,
     ) -> Signal:
-        """
-        Cuts the signal according to the *start* and *stop* values, by using
+        """Cut the signal according to the *start* and *stop* values, by using
         the insertion indexes in the signal's *time* axis.
 
         Parameters
@@ -840,7 +838,7 @@ class Signal:
         return result
 
     def extend(self, other: Signal) -> Signal:
-        """extend signal with samples from another signal
+        """Extend Signal with samples from another Signal.
 
         Parameters
         ----------
@@ -916,7 +914,7 @@ class Signal:
             FloatInterpolationModeType | FloatInterpolation
         ) = FloatInterpolation.LINEAR_INTERPOLATION,
     ) -> Signal:
-        """returns a new *Signal* interpolated using the *new_timestamps*
+        """Returns a new *Signal* interpolated using the *new_timestamps*.
 
         Parameters
         ----------
@@ -1369,7 +1367,7 @@ class Signal:
         self.samples[idx] = val
 
     def astype(self, np_type: DTypeLike) -> Signal:
-        """returns new *Signal* with samples of dtype *np_type*
+        """Returns new *Signal* with samples of dtype *np_type*.
 
         Parameters
         ----------
@@ -1401,8 +1399,7 @@ class Signal:
         )
 
     def physical(self, copy: bool = True) -> Signal:
-        """
-        get the physical samples values
+        """Get the physical samples values.
 
         Parameters
         ----------
@@ -1452,7 +1449,7 @@ class Signal:
         )
 
     def validate(self, copy: bool = True) -> Signal:
-        """apply invalidation bits if they are available for this signal
+        """Apply invalidation bits if they are available for this signal.
 
         Parameters
         ----------
@@ -1498,7 +1495,7 @@ class Signal:
         return signal
 
     def copy(self) -> Signal:
-        """copy all attributes to a new Signal"""
+        """Copy all attributes to a new Signal."""
         return Signal(
             self.samples.copy(),
             self.timestamps.copy(),

--- a/src/asammdf/signal.py
+++ b/src/asammdf/signal.py
@@ -480,10 +480,20 @@ class Signal:
 
         Examples
         --------
+        >>> from asammdf import Signal
+        >>> import numpy as np
+        >>> old_sig = Signal(np.arange(0.03, 100, 0.05), np.arange(0.03, 100, 0.05), name='SIG')
         >>> new_sig = old_sig.cut(1.0, 10.5)
         >>> new_sig.timestamps[0], new_sig.timestamps[-1]
-        0.98, 10.48
+        (1.0, 10.5)
 
+        >>> new_sig = old_sig.cut(1.0, 10.5, include_ends=False)
+        >>> new_sig.timestamps[0], new_sig.timestamps[-1]
+        (1.03, 10.48)
+
+        >>> new_sig = old_sig.cut(1.0, 10.5, float_interpolation_mode=0)
+        >>> new_sig.samples[0], new_sig.samples[-1]
+        (0.98, 10.48)
         """
 
         integer_interpolation_mode = IntegerInterpolation(integer_interpolation_mode)

--- a/src/asammdf/signal.py
+++ b/src/asammdf/signal.py
@@ -451,7 +451,7 @@ class Signal:
             stop timestamp for cutting
         include_ends : bool
             include the *start* and *stop* timestamps after cutting the signal.
-            If *start* and *stop* are found in the original timestamps, then
+            If *start* and *stop* are not found in the original timestamps, then
             the new samples will be computed using interpolation. Default *True*
 
         integer_interpolation_mode : int

--- a/test/asammdf/gui/test_base.py
+++ b/test/asammdf/gui/test_base.py
@@ -12,6 +12,7 @@ class DragAndDrop
     - responsible to perform Drag and Drop operations
      from source widget - specific point, to destination widget - specific point
 """
+
 from collections.abc import Iterable
 import os
 import pathlib

--- a/test/asammdf/gui/widgets/Shortcuts/test_PlotGraphicsWidget_Shortcuts.py
+++ b/test/asammdf/gui/widgets/Shortcuts/test_PlotGraphicsWidget_Shortcuts.py
@@ -16,7 +16,6 @@ from test.asammdf.gui.widgets.test_BasePlotWidget import TestPlotWidget
 
 
 class TestPlotGraphicsShortcuts(TestPlotWidget):
-
     def setUp(self):
         """
         Events:

--- a/test/run_all.py
+++ b/test/run_all.py
@@ -3,6 +3,7 @@
 """
 Main test function to execute all tests found in the current directory
 """
+
 from pathlib import Path
 import sys
 import unittest

--- a/test/test_cantp.py
+++ b/test/test_cantp.py
@@ -19,7 +19,6 @@ class TestCANTP(unittest.TestCase):
     ts = np.array([0.112, 0.113, 0.116, 0.201])
 
     def test_merge_cantp(self):
-
         merged, t = blu.merge_cantp(TestCANTP.payload, TestCANTP.ts)
 
         assert merged.shape == (1, 11)

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 isolated_build = true
-envlist = py39, py310, py311, py312, py313, black, mypy, ruff, doc
+envlist = py39, py310, py311, py312, py313, mypy, ruff, doc
 
 [testenv:{py39,py310,py311,py312,py313}]
 deps =
@@ -20,13 +20,6 @@ setenv =
     QT_DEBUG_PLUGINS = 1
 commands =
     pytest --cov --cov-report=lcov
-
-[testenv:black]
-deps =
-    black~=25.1  # Aligned with .pre-commit-config.yaml
-skip_install = true
-commands =
-    black --config pyproject.toml --check . asammdf.spec
 
 [testenv:mypy]
 deps =
@@ -49,6 +42,7 @@ deps =
 skip_install = true
 commands =
     ruff check
+    ruff format --check
 
 [testenv:doc]
 deps =
@@ -75,7 +69,7 @@ commands =
 
 [gh-actions]
 python =
-    3.9: py39, black, mypy, ruff, doc
+    3.9: py39, mypy, ruff, doc
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
This PR replaces black with ruff's formatter. Ruff is already used for linting so why not use one tool instead of two here.

Line length is kept at 120.

As seen in ee60e89, some things are formatted a little differently although ruff is designed as a drop-in replacement for black. 
Some deviations are known and I think in this case these are all the deviations happening:
* https://docs.astral.sh/ruff/formatter/black/#blank-lines-at-the-start-of-a-block
* https://docs.astral.sh/ruff/formatter/black/#f-strings
* https://docs.astral.sh/ruff/formatter/black/#implicit-concatenated-strings
* https://docs.astral.sh/ruff/formatter/black/#call-chain-calls-break-differently-in-some-cases
