### PR TITLE
fix: TypeIs requires typing-extensions 4.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "numpy>=1.23.0",
     "pandas",
     "python-dateutil",
-    "typing-extensions~=4.6",
+    "typing-extensions~=4.10",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes #1158 

https://typing-extensions.readthedocs.io/en/latest/index.html#typing_extensions.TypeIs