### PR TITLE
Fix lint issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ ignore = [
     "PLW2901", # redefined-loop-name
     "RUF012",  # mutable-class-default
     "RUF015",  # unnecessary-iterable-allocation-for-first-element
+    "UP038",   # non-pep604-isinstance
 ]
 
 [tool.ruff.lint.isort]

--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -637,8 +637,8 @@ class MDF4(MDF_Common[Group]):
                     record_size = channel_group.samples_byte_nr + channel_group.invalidation_bytes_nr
 
             if self.identification["unfinalized_standard_flags"] & v4c.FLAG_UNFIN_UPDATE_CG_COUNTER:
-                total_size = int(10**12)
-                inval_total_size = int(10**12)
+                total_size = 10**12
+                inval_total_size = 10**12
 
             data_blocks_info = self._get_data_blocks_info(
                 address=address,
@@ -9525,7 +9525,7 @@ class MDF4(MDF_Common[Group]):
                             if split_size == 0:
                                 split_size = samples_size
                             chunks = float(total_size) / split_size
-                            chunks = int(ceil(chunks))
+                            chunks = ceil(chunks)
 
                             self._read_fragment_size = split_size
                         else:
@@ -9835,7 +9835,7 @@ class MDF4(MDF_Common[Group]):
                             split_size = self._write_fragment_size
                             if self._write_fragment_size:
                                 chunks = float(len(sdata)) / split_size
-                                chunks = int(ceil(chunks))
+                                chunks = ceil(chunks)
                             else:
                                 chunks = 1
 

--- a/src/asammdf/blocks/utils.py
+++ b/src/asammdf/blocks/utils.py
@@ -1968,7 +1968,7 @@ class _ChannelComputedDict(_ChannelBaseDict):
     user_defined_name: str | None
 
 
-_ChannelDict = Union[_ChannelComputedDict, _ChannelNotComputedDict]
+_ChannelDict = _ChannelComputedDict | _ChannelNotComputedDict
 
 
 class _ChannelGroupDict(TypedDict):

--- a/src/asammdf/gui/dialogs/error_dialog.py
+++ b/src/asammdf/gui/dialogs/error_dialog.py
@@ -8,7 +8,7 @@ from ..ui.error_dialog import Ui_ErrorDialog
 class ErrorDialog(Ui_ErrorDialog, QtWidgets.QDialog):
     def __init__(self, title, message, trace, *args, **kwargs):
         remote = kwargs.pop("remote", False)
-        timeout = kwargs.pop("timeout", int(os.environ.get("ASAMMDF_ERROR_DIALOG_TIMEOUT", 90)))
+        timeout = kwargs.pop("timeout", int(os.environ.get("ASAMMDF_ERROR_DIALOG_TIMEOUT", "90")))
         logger = kwargs.pop("logger", None)
 
         super().__init__(*args, **kwargs)

--- a/src/asammdf/gui/dialogs/messagebox.py
+++ b/src/asammdf/gui/dialogs/messagebox.py
@@ -2,7 +2,7 @@ import os
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
-DEFAULT_TIMEOUT = int(os.environ.get("ASAMMDF_ERROR_DIALOG_TIMEOUT", 60))
+DEFAULT_TIMEOUT = int(os.environ.get("ASAMMDF_ERROR_DIALOG_TIMEOUT", "60"))
 
 
 class MessageBox(QtWidgets.QMessageBox):

--- a/src/asammdf/gui/widgets/can_bus_trace.py
+++ b/src/asammdf/gui/widgets/can_bus_trace.py
@@ -37,7 +37,7 @@ class CANBusTrace(TabularBase):
 
         super().__init__(signals, ranges)
 
-        self.signals_descr = {name: 0 for name in signals.columns}
+        self.signals_descr = dict.fromkeys(signals.columns, 0)
         self.start = start.astimezone(LOCAL_TIMEZONE)
         self.pattern = {}
         self.format = format

--- a/src/asammdf/gui/widgets/flexray_bus_trace.py
+++ b/src/asammdf/gui/widgets/flexray_bus_trace.py
@@ -37,7 +37,7 @@ class FlexRayBusTrace(TabularBase):
 
         super().__init__(signals, ranges)
 
-        self.signals_descr = {name: 0 for name in signals.columns}
+        self.signals_descr = dict.fromkeys(signals.columns, 0)
         self.start = start.astimezone(LOCAL_TIMEZONE)
         self.pattern = {}
         self.format = format

--- a/src/asammdf/gui/widgets/formated_axis.py
+++ b/src/asammdf/gui/widgets/formated_axis.py
@@ -767,8 +767,8 @@ class FormatedAxis(pg.AxisItem):
 
             elif isinstance(lineAlpha, float):
                 lineAlpha *= 255
-                lineAlpha = max(0, int(round(lineAlpha)))
-                lineAlpha = min(255, int(round(lineAlpha)))
+                lineAlpha = max(0, round(lineAlpha))
+                lineAlpha = min(255, round(lineAlpha))
             elif isinstance(lineAlpha, int):
                 if (lineAlpha > 255) or (lineAlpha < 0):
                     raise ValueError("lineAlpha should be [0..255]")

--- a/src/asammdf/gui/widgets/lin_bus_trace.py
+++ b/src/asammdf/gui/widgets/lin_bus_trace.py
@@ -29,7 +29,7 @@ class LINBusTrace(TabularBase):
 
         super().__init__(signals, ranges)
 
-        self.signals_descr = {name: 0 for name in signals.columns}
+        self.signals_descr = dict.fromkeys(signals.columns, 0)
         self.start = start.astimezone(LOCAL_TIMEZONE)
         self.pattern = {}
         self.format = format

--- a/src/asammdf/types.py
+++ b/src/asammdf/types.py
@@ -20,24 +20,24 @@ if TYPE_CHECKING:
 
 StrPathType = Union[str, "PathLike[str]"]
 StrOrBytesPathType = Union[str, bytes, "PathLike[str]", "PathLike[bytes]"]
-ReadableBufferType = Union[BufferedRandom, BufferedReader, BytesIO, mmap]
-WritableBufferType = Union[BufferedRandom, BufferedWriter, BytesIO, mmap]
+ReadableBufferType = BufferedRandom | BufferedReader | BytesIO | mmap
+WritableBufferType = BufferedRandom | BufferedWriter | BytesIO | mmap
 
 # asammdf specific types
 
 BusType = Literal["CAN", "LIN"]
 ChannelConversionType = Union["v2_v3_blocks.ChannelConversion", "v4_blocks.ChannelConversion"]
 ChannelGroupType = Union["v2_v3_blocks.ChannelGroup", "v4_blocks.ChannelGroup"]
-ChannelsType = Union[Sequence[str], Sequence[tuple[str | None, int, int]], Sequence[tuple[str, int]]]
+ChannelsType = Sequence[str] | Sequence[tuple[str | None, int, int]] | Sequence[tuple[str, int]]
 ChannelType = Union["v2_v3_blocks.Channel", "v4_blocks.Channel"]
 CompressionType = Union[Literal[0, 1, 2, 3, 4, 5], "v4_constants.CompressionAlgorithm"]
 DataGroupType = Union["v2_v3_blocks.DataGroup", "v4_blocks.DataGroup"]
 DbcFileType = tuple[StrPathType | CanMatrix, int]
 EmptyChannelsType = Literal["skip", "zeros"]
 FloatInterpolationModeType = Literal[0, 1]
-InputType = Union[BufferedReader, BytesIO, StrPathType, ZipFile, BZ2File, GzipFile]
+InputType = BufferedReader | BytesIO | StrPathType | ZipFile | BZ2File | GzipFile
 IntInterpolationModeType = Literal[0, 1, 2]
 MDF_v2_v3_v4 = Union["MDF2", "MDF3", "MDF4"]
-RasterType = Union[float, str, NDArray[Any]]
+RasterType = float | str | NDArray[Any]
 SourceType = Union["v2_v3_blocks.ChannelExtension", "v4_blocks.SourceInformation", "Source"]
 SyncType = Literal[0, 1, 2, 3, 4]

--- a/test/asammdf/gui/resources/functions.py
+++ b/test/asammdf/gui/resources/functions.py
@@ -4,7 +4,7 @@ import numpy as np
 def Function1(t=0):
     sequence = range(10)
     filtered = list(filter(lambda i: i % 2, sequence))
-    if len(filtered):
+    if filtered:
         for _ in filtered:
             if not _:
                 continue


### PR DESCRIPTION
The rules fixed in 82e60e7c1307969add2c78326d4b9a8faccf8561 were stabilized in ruff 0.10, previously only preview. UP007 error fixed in fe2391c283dd03a7d606a4b8ca83b56ebec8875e is due to target-version changed to py310.

I haven't raised the ruff version here but will do so in #1151.