### PR TITLE
Raise min. dependency versions for numpy2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,21 +37,20 @@ dependencies = [
     "isal; platform_machine == 'x86_64' or platform_machine == 'AMD64'",
     "lxml>=4.9.3",
     "lz4",
-    "numexpr",
+    "numexpr>=2.10.0",
     "numpy>=2.0.0",
-    "pandas",
+    "pandas>=2.2.2",
     "python-dateutil",
     "typing-extensions~=4.10",
 ]
 
 [project.optional-dependencies]
 decode = ["faust-cchardet==2.1.19", "chardet"]
-export = ["pyarrow", "h5py", "hdf5storage>=0.1.19", "python-snappy", "polars"]
-testing = ["h5py", "pyarrow", "python-can", "scipy"]
-export-matlab-v5 = ["scipy"]
-gui = ["natsort", "PySide6", "pyqtgraph", "pyqtlet2[PySide6]", "packaging"]
+export = ["pyarrow>=17.0.0", "h5py>=3.11", "hdf5storage>=0.1.19", "python-snappy", "polars>=1.1.0"]
+export-matlab-v5 = ["scipy>=1.13.0"]
+gui = ["natsort", "PySide6>=6.7.0", "pyqtgraph>=0.13.4", "pyqtlet2[PySide6]", "packaging"]
 encryption = ["cryptography", "keyring"]
-symbolic-math = ["sympy"]
+symbolic-math = ["sympy>=1.13.0"]
 filesystem = ["fsspec"]
 
 [project.scripts]


### PR DESCRIPTION
When updating older asammdf installations, the dependencies are not automatically updated to ensure numpy 2.0 compatibility.
`PySide6>=6.7.0` is not numpy related, but older versions fail with an AttributeError.
I also removed the `testing` extra, i does not seem to be used anywhere.