### PR TITLE
Fix 'FigureCanvasTkAgg' object has no attribute 'set_window_title'

### DIFF
--- a/src/asammdf/signal.py
+++ b/src/asammdf/signal.py
@@ -325,7 +325,7 @@ class Signal:
                     shape = samples.shape[1:]
 
                     fig = plt.figure()
-                    fig.canvas.set_window_title(self.name)
+                    fig.canvas.manager.set_window_title(self.name)
                     fig.text(
                         0.95,
                         0.05,
@@ -380,7 +380,7 @@ class Signal:
 
                 else:
                     fig = plt.figure()
-                    fig.canvas.set_window_title(self.name)
+                    fig.canvas.manager.set_window_title(self.name)
                     fig.text(
                         0.95,
                         0.05,


### PR DESCRIPTION
This was partially fixed in #830 but two places were missed.