### PR TITLE
Copy docstrings for forwarded methods in MDF

### DIFF
--- a/src/asammdf/mdf.py
+++ b/src/asammdf/mdf.py
@@ -413,6 +413,34 @@ class MDF:
         # MDF(filename).convert('4.10')
         self._mdf._parent = self
 
+        # Copy docstrings for the _mdf methods that are "forwarded" in the MDF class
+        forwarded_methods = [
+            "add_trigger",
+            "append",
+            "attach",
+            "close",
+            "extend",
+            "extract_attachment",
+            "get",
+            "get_bus_signal",
+            "get_can_signal",
+            "get_channel_comment",
+            "get_channel_metadata",
+            "get_channel_name",
+            "get_channel_unit",
+            "get_invalidation_bits",
+            "get_lin_signal",
+            "get_master",
+            "included_channels",
+            "info",
+            "iter_get_triggers",
+            "reload_header",
+            "save",
+        ]
+        for method_name in forwarded_methods:
+            _mdf_method = getattr(self._mdf, method_name, None)
+            getattr(self, method_name).__func__.__doc__ = _mdf_method.__doc__ if _mdf_method else None
+
     def __enter__(self) -> "MDF":
         return self
 


### PR DESCRIPTION
Viewing the docstring/help is currently not possible for methods in MDF that are originally implemented in MDF3 and/or MDF4, for example `get`.

I think this is an unintended side effect of the recent _and excellent_ type safety work by @JulienGrv. `get` and some other methods are explicitly redefined in the MDF class and just forwarding the value from their equivalents in the `_mdf` object, and from reading [this discussion](https://github.com/danielhrisca/asammdf/pull/1196#discussion_r2072106891) I understand why it was done. What is missing is just the connection to the docstring of the underlying method, from either MDF3 or MDF4.

In this PR I solve it by copying `__doc__` from `MDF._mdf.method_name` to `MDF.method_name` in `__init__`. It works but there might be some other issue I have overlooked.