### PR TITLE
Set fail-fast: false in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         python-version: ["3.12"]


### PR DESCRIPTION
The arm build currently fails because of https://github.com/mcfletch/pyopengl/pull/146.
Set fail-fast: false so the other OS versions can be completed.