### PR TITLE
Stop catching KeyboardInterrupt

### DIFF
--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -8976,7 +8976,7 @@ class MDF4(MDF_Common[Group]):
         while True:
             try:
                 fragments = [next(stream) for stream in data_streams]
-            except:
+            except Exception:
                 break
             #
             # if perf_counter() - tt > 120:


### PR DESCRIPTION
This line without an exception type can make it hard to interrupt scripts.
Moreover, if trying to interrupt e.g. with Ctrl+C while in this try-except block, I guess you might silently loose data.