### PR TITLE
fix: mypy errors introduced by numpy 2.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ skip = ["pp*", "*_ppc64le", "*-musllinux*", "*_s390x"]
 files = "."
 exclude = ["build/", "ci/", "dist/", "doc/_build/", "ext/", "test/asammdf/gui/"]
 python_version = "3.10"
-plugins = ["numpy.typing.mypy_plugin"]
 enable_error_code = ["deprecated"]
 strict = true
 

--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -12108,9 +12108,9 @@ class MDF4(MDF_Common[Group]):
 
                 for bus in buses:
                     bus_msg_ids = msg_ids[bus_ids == bus]
-                    unique_ids = unique(bus_msg_ids)
-                    unique_ids.sort()
-                    unique_ids = unique_ids.tolist()
+                    unique_id_array = unique(bus_msg_ids)
+                    unique_id_array.sort()
+                    unique_ids = typing.cast(list[int], unique_id_array.tolist())
 
                     bus_map = self.bus_logging_map["CAN"].setdefault(bus, {})
 

--- a/src/asammdf/blocks/v4_blocks.py
+++ b/src/asammdf/blocks/v4_blocks.py
@@ -3302,6 +3302,8 @@ class ChannelConversion(_ChannelConversionBase):
 
         values_count = len(new_values)
 
+        index: np.intp | int
+
         conversion_type = self.conversion_type
         if conversion_type == v4c.CONVERSION_TYPE_NON:
             pass


### PR DESCRIPTION
NumPy improved its type annotations in release 2.3.0, resulting in two new errors fixed in this PR. Note that the mypy plugin has been deprecated