### PR TITLE
Investigate `CI` tests failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         run: tox
 
       - uses: actions/upload-artifact@v4
-        if: failure() && matrix.os == 'windows-latest' # 'ubuntu-22.04' or 'windows-latest'
+        if: failure() # && matrix.os == 'windows-latest' # 'ubuntu-22.04' or 'windows-latest'
         with:
           path: "**/screenshots/**"
           name: screenshots-${{ matrix.os }}-${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,11 +43,11 @@ jobs:
       - name: Start Xvfb
         if: matrix.os == 'ubuntu-22.04'
         run: |
-          Xvfb :0 -screen 0 1024x768x24 > /dev/null 2>&1 &
+          Xvfb :0 -screen 0 1280x720x24 > /dev/null 2>&1 &
           export DISPLAY=:0
           touch ~/.Xauthority
 
-          Xvfb :0 -screen 0 1024x768x24 > /dev/null 2>&1 &
+          Xvfb :0 -screen 0 1280x720x24 > /dev/null 2>&1 &
           export DISPLAY=:0
 
       # see: https://github.com/ymyzk/tox-gh-actions
@@ -58,7 +58,7 @@ jobs:
         if: failure() && matrix.os == 'windows-latest' # 'ubuntu-22.04' or 'windows-latest'
         with:
           path: "**/screenshots/**"
-          name: ${{ matrix.python-version }}
+          name: screenshots-${{ matrix.os }}-${{ matrix.python-version }}
 
       - name: Stop Xvfb
         if: matrix.os == 'ubuntu-22.04'

--- a/test/asammdf/gui/test_base.py
+++ b/test/asammdf/gui/test_base.py
@@ -63,7 +63,7 @@ class TestBase(unittest.TestCase):
 
     resource = os.path.normpath(os.path.join(os.path.dirname(__file__), "resources"))
     test_workspace = os.path.join(os.path.dirname(__file__), "test_workspace")
-    screenshots = os.path.join(os.path.dirname(__file__).split("test")[0], "screenshots")
+    screenshots = os.path.join(os.path.dirname(__file__), "screenshots")
 
     patchers = []
     # MockClass ErrorDialog
@@ -114,7 +114,11 @@ class TestBase(unittest.TestCase):
         if not os.path.exists(self.screenshots):
             os.makedirs(self.screenshots)
 
-        os.makedirs(self.test_workspace)
+        try:
+            os.makedirs(self.test_workspace)
+        except FileExistsError as e:
+            pass
+
         self.mc_ErrorDialog.reset_mock()
         self.processEvents()
 
@@ -133,13 +137,8 @@ class TestBase(unittest.TestCase):
 
     def tearDown(self):
         self.processEvents()
-        path_ = os.path.join(self.screenshots, self.id().split("gui.")[-1].rsplit(".", 1)[0])
-        if not os.path.exists(path_):
-            os.makedirs(path_)
-
         w = getattr(self, "widget", None)
         if w:
-            w.grab().save(os.path.join(path_, f"{self.id().split('.')[-1]}.png"))
             self.destroy(w)
 
         self.mc_ErrorDialog.reset_mock()

--- a/test/asammdf/gui/test_base.py
+++ b/test/asammdf/gui/test_base.py
@@ -111,13 +111,9 @@ class TestBase(unittest.TestCase):
                 shutil.rmtree(self.test_workspace)
             except PermissionError as e:
                 print(e)
-        if not os.path.exists(self.screenshots):
-            os.makedirs(self.screenshots)
 
-        try:
-            os.makedirs(self.test_workspace)
-        except FileExistsError as e:
-            pass
+        os.makedirs(self.screenshots, exist_ok=True)
+        os.makedirs(self.test_workspace, exist_ok=True)
 
         self.mc_ErrorDialog.reset_mock()
         self.processEvents()

--- a/test/asammdf/gui/widgets/Shortcuts/test_PlotGraphicsWidget_Shortcuts.py
+++ b/test/asammdf/gui/widgets/Shortcuts/test_PlotGraphicsWidget_Shortcuts.py
@@ -320,7 +320,6 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         self.assertAlmostEqual(self.pg.x_range[0], x_range[0], delta=0.001)
         self.assertAlmostEqual(self.pg.x_range[1], x_range[1], delta=0.001)
 
-    # @unittest.skip("FIXME: test keeps failing in CI")
     def test_fit__stack_shortcuts(self):
         """
         Test Scope:
@@ -369,6 +368,10 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         channel_35 = self.channels[0]
         channel_36 = self.channels[1]
         channel_37 = self.channels[2]
+        color_35 = channel_35.color.name()
+        color_36 = channel_36.color.name()
+        color_37 = channel_37.color.name()
+
         # Press "S"
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["stack_all"]))
         self.processEvents()
@@ -378,9 +381,9 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
             self.assertTrue(Pixmap.is_black(self.pg.grab(QRect(0, 0, self.pg.width(), 1))))
             # Top
             pixmap = self.pg.grab(QRect(0, 0, self.pg.width(), int(self.pg.height() / 3)))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_35.color.name()))
-            self.assertFalse(Pixmap.has_color(pixmap, channel_36.color.name()))
-            self.assertFalse(Pixmap.has_color(pixmap, channel_37.color.name()))
+            self.assertTrue(Pixmap.has_color(pixmap, color_35))
+            self.assertFalse(Pixmap.has_color(pixmap, color_36))
+            self.assertFalse(Pixmap.has_color(pixmap, color_37))
             # Midd
             pixmap = self.pg.grab(
                 QRect(
@@ -390,9 +393,9 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
                     int(self.pg.height() / 3),
                 )
             )
-            self.assertFalse(Pixmap.has_color(pixmap, channel_35.color.name()))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_36.color.name()))
-            self.assertFalse(Pixmap.has_color(pixmap, channel_37.color.name()))
+            self.assertFalse(Pixmap.has_color(pixmap, color_35))
+            self.assertTrue(Pixmap.has_color(pixmap, color_36))
+            self.assertFalse(Pixmap.has_color(pixmap, color_37))
             # Bottom
             pixmap = self.pg.grab(
                 QRect(
@@ -402,31 +405,29 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
                     int(self.pg.height() / 3),
                 )
             )
-            self.assertFalse(Pixmap.has_color(pixmap, channel_35.color.name()))
-            self.assertFalse(Pixmap.has_color(pixmap, channel_36.color.name()))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_37.color.name()))
+            self.assertFalse(Pixmap.has_color(pixmap, color_35))
+            self.assertFalse(Pixmap.has_color(pixmap, color_36))
+            self.assertTrue(Pixmap.has_color(pixmap, color_37))
             # Last 2 lines
 
             pixmap = self.pg.grab(QRect(0, self.pg.height() - 3, self.pg.width(), 2))
-            cn = Pixmap.color_names_exclude_defaults(pixmap)
-            self.assertEqual(len(cn), 0)
+            self.assertTrue(Pixmap.is_black(pixmap))
 
         # select the first channel
         self.mouseClick_WidgetItem(channel_35)
         # Press "Shift+F"
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["fit_selected"]))
-        self.avoid_blinking_issue(self.plot.channel_selection)
-        for _ in range(50):
-            self.processEvents()
+        self.is_not_blinking(self.pg, {color_35, color_36, color_37})
+
         # Evaluate
         with self.subTest("test_fit_selected_shortcut"):
             # First line
             self.assertTrue(Pixmap.is_black(self.pg.grab(QRect(0, 0, self.pg.width(), 1))))
             # Top
             pixmap = self.pg.grab(QRect(0, 0, self.pg.width(), int(self.pg.height() / 3)))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_35.color.name()))
-            self.assertFalse(Pixmap.has_color(pixmap, channel_36.color.name()))
-            self.assertFalse(Pixmap.has_color(pixmap, channel_37.color.name()))
+            self.assertTrue(Pixmap.has_color(pixmap, color_35))
+            self.assertFalse(Pixmap.has_color(pixmap, color_36))
+            self.assertFalse(Pixmap.has_color(pixmap, color_37))
             # Midd
             pixmap = self.pg.grab(
                 QRect(
@@ -436,9 +437,9 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
                     int(self.pg.height() / 3),
                 )
             )
-            self.assertTrue(Pixmap.has_color(pixmap, channel_35.color.name()))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_36.color.name()))
-            self.assertFalse(Pixmap.has_color(pixmap, channel_37.color.name()))
+            self.assertTrue(Pixmap.has_color(pixmap, color_35))
+            self.assertTrue(Pixmap.has_color(pixmap, color_36))
+            self.assertFalse(Pixmap.has_color(pixmap, color_37))
             # Bottom
             pixmap = self.pg.grab(
                 QRect(
@@ -448,9 +449,9 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
                     int(self.pg.height() / 3),
                 )
             )
-            self.assertTrue(Pixmap.has_color(pixmap, channel_35.color.name()))
-            self.assertFalse(Pixmap.has_color(pixmap, channel_36.color.name()))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_37.color.name()))
+            self.assertTrue(Pixmap.has_color(pixmap, color_35))
+            self.assertFalse(Pixmap.has_color(pixmap, color_36))
+            self.assertTrue(Pixmap.has_color(pixmap, color_37))
             # Last line
             self.assertTrue(Pixmap.is_black(self.pg.grab(QRect(0, self.pg.height() - 2, self.pg.width(), 1))))
 
@@ -458,20 +459,16 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         self.mouseClick_WidgetItem(channel_36)
         # Press "Shift+F"
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["stack_selected"]))
-        self.avoid_blinking_issue(self.plot.channel_selection)
-        for _ in range(10):
-            self.processEvents(0.01)
-        self.processEvents(0.1)  # only py310 continue failing because of unprocessed graphics
+        self.is_not_blinking(self.pg, {color_35, color_36, color_37})
         # Evaluate
         with self.subTest("test_stack_selected_shortcut"):
             # First line
             self.assertTrue(Pixmap.is_black(self.pg.grab(QRect(0, 0, self.pg.width(), 1))))
             # Top
             pixmap = self.pg.grab(QRect(0, 0, self.pg.width(), int(self.pg.height() / 3)))
-            self.pg.grab().save(os.path.join(self.screenshots, f"{self.id()}.png"))  # debug
-            self.assertTrue(Pixmap.has_color(pixmap, channel_35.color.name()))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_36.color.name()))
-            self.assertFalse(Pixmap.has_color(pixmap, channel_37.color.name()))
+            self.assertTrue(Pixmap.has_color(pixmap, color_35))
+            self.assertTrue(Pixmap.has_color(pixmap, color_36))
+            self.assertFalse(Pixmap.has_color(pixmap, color_37))
             # Midd
             pixmap = self.pg.grab(
                 QRect(
@@ -481,9 +478,9 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
                     int(self.pg.height() / 3),
                 )
             )
-            self.assertTrue(Pixmap.has_color(pixmap, channel_35.color.name()))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_36.color.name()))
-            self.assertFalse(Pixmap.has_color(pixmap, channel_37.color.name()))
+            self.assertTrue(Pixmap.has_color(pixmap, color_35))
+            self.assertTrue(Pixmap.has_color(pixmap, color_36))
+            self.assertFalse(Pixmap.has_color(pixmap, color_37))
             # Bottom
             pixmap = self.pg.grab(
                 QRect(
@@ -493,24 +490,24 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
                     int(self.pg.height() / 3),
                 )
             )
-            self.assertTrue(Pixmap.has_color(pixmap, channel_35.color.name()))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_36.color.name()))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_37.color.name()))
+            self.assertTrue(Pixmap.has_color(pixmap, color_35))
+            self.assertTrue(Pixmap.has_color(pixmap, color_36))
+            self.assertTrue(Pixmap.has_color(pixmap, color_37))
             # Last line
             self.assertTrue(Pixmap.is_black(self.pg.grab(QRect(0, self.pg.height() - 1, self.pg.width(), 1))))
 
             # Press "F"
             QTest.keySequence(self.pg, QKeySequence(self.shortcuts["fit_all"]))
-            self.avoid_blinking_issue(self.plot.channel_selection)
+            self.is_not_blinking(self.pg, {color_35, color_36, color_37})
             # Evaluate
         with self.subTest("test_fit_all_shortcut"):
             # First line
             self.assertTrue(Pixmap.is_black(self.pg.grab(QRect(0, 0, self.pg.width(), 1))))
             # Top
             pixmap = self.pg.grab(QRect(0, 0, self.pg.width(), int(self.pg.height() / 3)))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_35.color.name()))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_36.color.name()))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_37.color.name()))
+            self.assertTrue(Pixmap.has_color(pixmap, color_35))
+            self.assertTrue(Pixmap.has_color(pixmap, color_36))
+            self.assertTrue(Pixmap.has_color(pixmap, color_37))
             # Midd
             pixmap = self.pg.grab(
                 QRect(
@@ -520,9 +517,9 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
                     int(self.pg.height() / 3),
                 )
             )
-            self.assertTrue(Pixmap.has_color(pixmap, channel_35.color.name()))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_36.color.name()))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_37.color.name()))
+            self.assertTrue(Pixmap.has_color(pixmap, color_35))
+            self.assertTrue(Pixmap.has_color(pixmap, color_36))
+            self.assertTrue(Pixmap.has_color(pixmap, color_37))
             # Bottom
             pixmap = self.pg.grab(
                 QRect(
@@ -532,9 +529,9 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
                     int(self.pg.height() / 3),
                 )
             )
-            self.assertTrue(Pixmap.has_color(pixmap, channel_35.color.name()))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_36.color.name()))
-            self.assertTrue(Pixmap.has_color(pixmap, channel_37.color.name()))
+            self.assertTrue(Pixmap.has_color(pixmap, color_35))
+            self.assertTrue(Pixmap.has_color(pixmap, color_36))
+            self.assertTrue(Pixmap.has_color(pixmap, color_37))
             # Last line
             self.assertTrue(Pixmap.is_black(self.pg.grab(QRect(0, self.pg.height() - 1, self.pg.width(), 1))))
 
@@ -986,8 +983,6 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         self.assertEqual(f"{ci.name} = {round(ch.signal.timestamps[pos], ci.precision)}{ci.unit}", ci.text())
         self.assertEqual(ch.signal.timestamps[pos], self.pg.cursor1.getXPos())
 
-    # @unittest.skip("FIXME: test keeps failing in CI")
-    # @unittest.skipIf(sys.platform != "win32", "RuntimeError. C++ object <<ViewBoxWithCursor>> already deleted.")
     def test_shift_channels_shortcut(self):
         """
         Test Scope:
@@ -1031,8 +1026,7 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["shift_channels_down_1x"]))
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["shift_channels_left"]))
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["shift_channels_left"]))
-        self.avoid_blinking_issue(self.plot.channel_selection)
-        self.processEvents()
+        self.is_not_blinking(self.pg, {channel_36.color.name(), channel_37.color.name()})
 
         # Select second channel and move signal using commands Shift + PgUp/Up/Right
         self.mouseClick_WidgetItem(channel_37)
@@ -1040,9 +1034,7 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["shift_channels_up_1x"]))
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["shift_channels_right"]))
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["shift_channels_right"]))
-        self.avoid_blinking_issue(self.plot.channel_selection)
-        for _ in range(10):
-            self.processEvents(0.01)
+        self.is_not_blinking(self.pg, {channel_36.color.name(), channel_37.color.name()})
 
         # Find new extremes
         new_from_to_y_channel_36 = Pixmap.search_signal_extremes_by_ax(self.pg.grab(), channel_36.color.name(), "y")
@@ -1092,7 +1084,7 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         expected_normal_screen_honey_range = find_honey_range(self.pg)
         # Press "H"
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["honeywell"]))
-        self.avoid_blinking_issue(self.plot.channel_selection)
+        self.processEvents(0.01)
         delta_normal_screen_x_range = self.pg.x_range[1] - self.pg.x_range[0]
         # Evaluate
         self.assertAlmostEqual(delta_normal_screen_x_range, expected_normal_screen_honey_range, delta=0.0001)
@@ -1106,14 +1098,13 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         expected_full_screen_honey_range = find_honey_range(self.pg)
         # Press "H"
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["honeywell"]))
-        self.avoid_blinking_issue(self.plot.channel_selection)
+        self.processEvents(0.01)
         delta_full_screen_x_range = self.pg.x_range[1] - self.pg.x_range[0]
 
         # Evaluate
         self.assertNotEqual(delta_full_screen_x_range, delta_normal_screen_x_range)
         self.assertAlmostEqual(delta_full_screen_x_range, expected_full_screen_honey_range, delta=0.0001)
 
-    # @unittest.skip("FIXME: test keeps failing in CI")
     def test_home_shortcuts(self):
         """
         Check if the signal is fitted properly after pressing key "W".

--- a/test/asammdf/gui/widgets/Shortcuts/test_PlotGraphicsWidget_Shortcuts.py
+++ b/test/asammdf/gui/widgets/Shortcuts/test_PlotGraphicsWidget_Shortcuts.py
@@ -461,13 +461,14 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         self.avoid_blinking_issue(self.plot.channel_selection)
         for _ in range(10):
             self.processEvents(0.01)
+        self.processEvents(0.1)  # only py310 continue failing because of unprocessed graphics
         # Evaluate
         with self.subTest("test_stack_selected_shortcut"):
             # First line
             self.assertTrue(Pixmap.is_black(self.pg.grab(QRect(0, 0, self.pg.width(), 1))))
             # Top
             pixmap = self.pg.grab(QRect(0, 0, self.pg.width(), int(self.pg.height() / 3)))
-            self.pg.grab().save(os.path.join(self.screenshots, f"{self.id()}.png")) # debug
+            self.pg.grab().save(os.path.join(self.screenshots, f"{self.id()}.png"))  # debug
             self.assertTrue(Pixmap.has_color(pixmap, channel_35.color.name()))
             self.assertTrue(Pixmap.has_color(pixmap, channel_36.color.name()))
             self.assertFalse(Pixmap.has_color(pixmap, channel_37.color.name()))
@@ -1054,7 +1055,7 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         self.assertLess(old_from_to_y_channel_36[1], new_from_to_y_channel_36[1])
         self.assertGreater(old_from_to_x_channel_36[0], new_from_to_x_channel_36[0])
         self.assertGreater(old_from_to_x_channel_36[1], new_from_to_x_channel_36[1])
-        
+
         self.assertGreater(old_from_to_y_channel_37[0], new_from_to_y_channel_37[0])
         self.assertGreater(old_from_to_y_channel_37[1], new_from_to_y_channel_37[1])
         self.assertLess(old_from_to_x_channel_37[0], new_from_to_x_channel_37[0])

--- a/test/asammdf/gui/widgets/Shortcuts/test_PlotGraphicsWidget_Shortcuts.py
+++ b/test/asammdf/gui/widgets/Shortcuts/test_PlotGraphicsWidget_Shortcuts.py
@@ -459,6 +459,7 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         # Press "Shift+F"
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["stack_selected"]))
         self.avoid_blinking_issue(self.plot.channel_selection)
+        self.processEvents(0.01)
         # Evaluate
         with self.subTest("test_stack_selected_shortcut"):
             # First line
@@ -1038,6 +1039,7 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["shift_channels_right"]))
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["shift_channels_right"]))
         self.avoid_blinking_issue(self.plot.channel_selection)
+        self.processEvents(0.1)
         self.processEvents(0.01)
 
         # Find new extremes

--- a/test/asammdf/gui/widgets/Shortcuts/test_PlotGraphicsWidget_Shortcuts.py
+++ b/test/asammdf/gui/widgets/Shortcuts/test_PlotGraphicsWidget_Shortcuts.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python\
 
 import os
-import sys
-import unittest
 from unittest import mock
 
 from PySide6.QtCore import QPoint, QRect, QSettings, Qt
@@ -322,7 +320,7 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         self.assertAlmostEqual(self.pg.x_range[0], x_range[0], delta=0.001)
         self.assertAlmostEqual(self.pg.x_range[1], x_range[1], delta=0.001)
 
-    @unittest.skip("FIXME: test keeps failing in CI")
+    # @unittest.skip("FIXME: test keeps failing in CI")
     def test_fit__stack_shortcuts(self):
         """
         Test Scope:
@@ -984,8 +982,8 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         self.assertEqual(f"{ci.name} = {round(ch.signal.timestamps[pos], ci.precision)}{ci.unit}", ci.text())
         self.assertEqual(ch.signal.timestamps[pos], self.pg.cursor1.getXPos())
 
-    @unittest.skip("FIXME: test keeps failing in CI")
-    @unittest.skipIf(sys.platform != "win32", "RuntimeError. C++ object <<ViewBoxWithCursor>> already deleted.")
+    # @unittest.skip("FIXME: test keeps failing in CI")
+    # @unittest.skipIf(sys.platform != "win32", "RuntimeError. C++ object <<ViewBoxWithCursor>> already deleted.")
     def test_shift_channels_shortcut(self):
         """
         Test Scope:
@@ -1039,7 +1037,7 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["shift_channels_right"]))
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["shift_channels_right"]))
         self.avoid_blinking_issue(self.plot.channel_selection)
-        self.processEvents()
+        self.processEvents(0.01)
 
         # Find new extremes
         new_from_to_y_channel_36 = Pixmap.search_signal_extremes_by_ax(self.pg.grab(), channel_36.color.name(), "y")
@@ -1110,7 +1108,7 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         self.assertNotEqual(delta_full_screen_x_range, delta_normal_screen_x_range)
         self.assertAlmostEqual(delta_full_screen_x_range, expected_full_screen_honey_range, delta=0.0001)
 
-    @unittest.skip("FIXME: test keeps failing in CI")
+    # @unittest.skip("FIXME: test keeps failing in CI")
     def test_home_shortcuts(self):
         """
         Check if the signal is fitted properly after pressing key "W".

--- a/test/asammdf/gui/widgets/Shortcuts/test_PlotGraphicsWidget_Shortcuts.py
+++ b/test/asammdf/gui/widgets/Shortcuts/test_PlotGraphicsWidget_Shortcuts.py
@@ -459,7 +459,8 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         # Press "Shift+F"
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["stack_selected"]))
         self.avoid_blinking_issue(self.plot.channel_selection)
-        self.processEvents(0.01)
+        for _ in range(10):
+            self.processEvents(0.01)
         # Evaluate
         with self.subTest("test_stack_selected_shortcut"):
             # First line
@@ -1039,12 +1040,10 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["shift_channels_right"]))
         QTest.keySequence(self.pg, QKeySequence(self.shortcuts["shift_channels_right"]))
         self.avoid_blinking_issue(self.plot.channel_selection)
-        self.processEvents(0.1)
-        self.processEvents(0.01)
+        for _ in range(10):
+            self.processEvents(0.01)
 
         # Find new extremes
-        self.pg.grab().save(os.path.join(self.screenshots, f"{self.id()}.png")) # debug
-
         new_from_to_y_channel_36 = Pixmap.search_signal_extremes_by_ax(self.pg.grab(), channel_36.color.name(), "y")
         new_from_to_y_channel_37 = Pixmap.search_signal_extremes_by_ax(self.pg.grab(), channel_37.color.name(), "y")
         new_from_to_x_channel_36 = Pixmap.search_signal_extremes_by_ax(self.pg.grab(), channel_36.color.name(), "x")

--- a/test/asammdf/gui/widgets/Shortcuts/test_PlotGraphicsWidget_Shortcuts.py
+++ b/test/asammdf/gui/widgets/Shortcuts/test_PlotGraphicsWidget_Shortcuts.py
@@ -465,6 +465,7 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
             self.assertTrue(Pixmap.is_black(self.pg.grab(QRect(0, 0, self.pg.width(), 1))))
             # Top
             pixmap = self.pg.grab(QRect(0, 0, self.pg.width(), int(self.pg.height() / 3)))
+            self.pg.grab().save(os.path.join(self.screenshots, f"{self.id()}.png")) # debug
             self.assertTrue(Pixmap.has_color(pixmap, channel_35.color.name()))
             self.assertTrue(Pixmap.has_color(pixmap, channel_36.color.name()))
             self.assertFalse(Pixmap.has_color(pixmap, channel_37.color.name()))
@@ -1040,6 +1041,8 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         self.processEvents(0.01)
 
         # Find new extremes
+        self.pg.grab().save(os.path.join(self.screenshots, f"{self.id()}.png")) # debug
+
         new_from_to_y_channel_36 = Pixmap.search_signal_extremes_by_ax(self.pg.grab(), channel_36.color.name(), "y")
         new_from_to_y_channel_37 = Pixmap.search_signal_extremes_by_ax(self.pg.grab(), channel_37.color.name(), "y")
         new_from_to_x_channel_36 = Pixmap.search_signal_extremes_by_ax(self.pg.grab(), channel_36.color.name(), "x")
@@ -1050,7 +1053,7 @@ class TestPlotGraphicsShortcuts(TestPlotWidget):
         self.assertLess(old_from_to_y_channel_36[1], new_from_to_y_channel_36[1])
         self.assertGreater(old_from_to_x_channel_36[0], new_from_to_x_channel_36[0])
         self.assertGreater(old_from_to_x_channel_36[1], new_from_to_x_channel_36[1])
-
+        
         self.assertGreater(old_from_to_y_channel_37[0], new_from_to_y_channel_37[0])
         self.assertGreater(old_from_to_y_channel_37[1], new_from_to_y_channel_37[1])
         self.assertLess(old_from_to_x_channel_37[0], new_from_to_x_channel_37[0])

--- a/test/asammdf/gui/widgets/batch/test_BatchWidget_Tab_ModifyAndExport.py
+++ b/test/asammdf/gui/widgets/batch/test_BatchWidget_Tab_ModifyAndExport.py
@@ -784,7 +784,7 @@ class TestPushButtonApply(TestBatchWidget):
                 self.assertEqual(channel.timestamps.min(), start_cut)
                 self.assertEqual(channel.timestamps.max(), stop_cut)
 
-    @unittest.skip("FIXME: test keeps failing in CI")
+    # @unittest.skip("FIXME: test keeps failing in CI")
     def test_resample_by_step_0(self):
         """
         Events
@@ -826,7 +826,7 @@ class TestPushButtonApply(TestBatchWidget):
                 for i in range(size):
                     self.assertAlmostEqual(channel.timestamps[i], channel.timestamps.min() + step * i, places=12)
 
-    @unittest.skip("FIXME: test keeps failing in CI")
+    # @unittest.skip("FIXME: test keeps failing in CI")
     def test_resample_by_step_1(self):
         """
         Events

--- a/test/asammdf/gui/widgets/plot/test_PlotWidget_ContextMenu.py
+++ b/test/asammdf/gui/widgets/plot/test_PlotWidget_ContextMenu.py
@@ -3,8 +3,6 @@ import json
 from json import JSONDecodeError
 import pathlib
 import re
-import sys
-import unittest
 from unittest import mock
 from unittest.mock import ANY
 
@@ -846,7 +844,7 @@ class TestContextMenu(TestPlotWidget):
             self.assertNotEqual(previous_c_color, current_c_color)
             self.assertNotEqual(current_b_color, current_c_color)
 
-    @unittest.skipIf(sys.platform == "win32", "times out on Windows")
+    # @unittest.skipIf(sys.platform == "win32", "times out on Windows")
     def test_Action_CopyDisplayProperties_Group(self):
         """
         Test Scope:
@@ -1047,7 +1045,7 @@ class TestContextMenu(TestPlotWidget):
             # Evaluate
             self.assertEqual(group_channel_a_properties, group_channel_b_properties)
 
-    @unittest.skipIf(sys.platform == "win32", "times out on Windows")
+    # @unittest.skipIf(sys.platform == "win32", "times out on Windows")
     def test_Action_CopyChannelStructure_Group(self):
         """
         Test Scope:

--- a/test/asammdf/gui/widgets/plot/test_PlotWidget_DoubleClick.py
+++ b/test/asammdf/gui/widgets/plot/test_PlotWidget_DoubleClick.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-import sys
-import unittest
 from unittest import mock
 
 from PySide6 import QtCore, QtGui, QtTest
@@ -176,7 +174,7 @@ class TestDoubleClick(TestPlotWidget):
                 msg=f"Color of channel {plot_channel_0.text(self.Column.NAME)} is not present on plot.",
             )
 
-    @unittest.skipIf(sys.platform == "win32", "fails on Windows")
+    # @unittest.skipIf(sys.platform == "win32", "fails on Windows")
     def test_EnableDisable_ParentGroup(self):
         """
         Test Scope:
@@ -317,7 +315,7 @@ class TestDoubleClick(TestPlotWidget):
                     msg=f"Color for Channel: {channel.text(self.Column.NAME)} not present on 'plot'",
                 )
 
-    @unittest.skipIf(sys.platform == "win32", "fails on Windows")
+    # @unittest.skipIf(sys.platform == "win32", "fails on Windows")
     def test_EnableDisable_Subgroup(self):
         """
         Test Scope:

--- a/test/asammdf/gui/widgets/test_BaseFileWidget.py
+++ b/test/asammdf/gui/widgets/test_BaseFileWidget.py
@@ -31,6 +31,7 @@ class TestFileWidget(TestBase):
         _outcome = getattr(self, "_outcome", None)
         if _outcome:
             failures = getattr(_outcome.result, "failures", None)
+            print(_outcome, type(_outcome), failures, sep="\n")
             if failures is not None:
                 # save last state graphical view of widget if failure
                 path = self.screenshots

--- a/test/asammdf/gui/widgets/test_BaseFileWidget.py
+++ b/test/asammdf/gui/widgets/test_BaseFileWidget.py
@@ -29,15 +29,17 @@ class TestFileWidget(TestBase):
 
     def tearDown(self):
         _outcome = getattr(self, "_outcome", None)
-        if _outcome.result.failures:
-            # save last state graphical view of widget if failure
-            path = self.screenshots
-            for name in self.id().split(".")[:-1]:
-                _path = os.path.join(path, name)
-                if not os.path.exists(_path):
-                    os.makedirs(_path)
-                path = _path
-            self.widget.grab().save(os.path.join(path, f"{self.id().split('.')[-1]}.png"))
+        if _outcome:
+            failures = getattr(_outcome.result, "failures", None)
+            if failures is not None:
+                # save last state graphical view of widget if failure
+                path = self.screenshots
+                for name in self.id().split(".")[:-1]:
+                    _path = os.path.join(path, name)
+                    if not os.path.exists(_path):
+                        os.makedirs(_path)
+                    path = _path
+                self.widget.grab().save(os.path.join(path, f"{self.id().split('.')[-1]}.png"))
 
         if self.widget is not None:
             self.widget.close()

--- a/test/asammdf/gui/widgets/test_BaseFileWidget.py
+++ b/test/asammdf/gui/widgets/test_BaseFileWidget.py
@@ -25,17 +25,18 @@ class TestFileWidget(TestBase):
         self.mc_widget_ed = patcher.start()
         self.addCleanup(patcher.stop)
 
-        self.measurement_file = shutil.copy(pathlib.Path(self.resource, "ASAP2_Demo_V171.mf4"), self.test_workspace)
+        try:  # is preferable to work with a copy of the file
+            self.measurement_file = shutil.copy(pathlib.Path(self.resource, "ASAP2_Demo_V171.mf4"), self.test_workspace)
+        except:  # but if old processes isn't finished or something keeps the file in use, do not fail the test
+            self.measurement_file = os.path.join(self.resource, "ASAP2_Demo_V171.mf4")
 
     def tearDown(self):
         _outcome = getattr(self, "_outcome", None)
         if _outcome:
             failures = getattr(_outcome.result, "failures", None)
-            _list = []
             for method in _outcome.result.__dir__():
                 if not method.startswith("__"):
-                    _list.append(method)
-            print(type(_outcome.result), _list, sep="\n")
+                    print(method, getattr(_outcome.result, method))
             if failures is not None:
                 # save last state graphical view of widget if failure
                 path = self.screenshots

--- a/test/asammdf/gui/widgets/test_BaseFileWidget.py
+++ b/test/asammdf/gui/widgets/test_BaseFileWidget.py
@@ -31,7 +31,11 @@ class TestFileWidget(TestBase):
         _outcome = getattr(self, "_outcome", None)
         if _outcome:
             failures = getattr(_outcome.result, "failures", None)
-            print(_outcome, type(_outcome), "", _outcome.result, type(_outcome.result), sep="\n")
+            _list = []
+            for method in _outcome.result.__dir__():
+                if not method.startswith("__"):
+                    _list.append(method)
+            print(type(_outcome.result), _list, sep="\n")
             if failures is not None:
                 # save last state graphical view of widget if failure
                 path = self.screenshots

--- a/test/asammdf/gui/widgets/test_BaseFileWidget.py
+++ b/test/asammdf/gui/widgets/test_BaseFileWidget.py
@@ -28,6 +28,17 @@ class TestFileWidget(TestBase):
         self.measurement_file = shutil.copy(pathlib.Path(self.resource, "ASAP2_Demo_V171.mf4"), self.test_workspace)
 
     def tearDown(self):
+        _outcome = getattr(self, "_outcome", None)
+        if _outcome.result.failures:
+            # save last state graphical view of widget if failure
+            path = self.screenshots
+            for name in self.id().split(".")[:-1]:
+                _path = os.path.join(path, name)
+                if not os.path.exists(_path):
+                    os.makedirs(_path)
+                path = _path
+            self.widget.grab().save(os.path.join(path, f"{self.id().split('.')[-1]}.png"))
+
         if self.widget is not None:
             self.widget.close()
         super().tearDown()

--- a/test/asammdf/gui/widgets/test_BaseFileWidget.py
+++ b/test/asammdf/gui/widgets/test_BaseFileWidget.py
@@ -31,7 +31,7 @@ class TestFileWidget(TestBase):
         _outcome = getattr(self, "_outcome", None)
         if _outcome:
             failures = getattr(_outcome.result, "failures", None)
-            print(_outcome, type(_outcome), failures, sep="\n")
+            print(_outcome, type(_outcome), "", _outcome.result, type(_outcome.result), sep="\n")
             if failures is not None:
                 # save last state graphical view of widget if failure
                 path = self.screenshots

--- a/test/asammdf/gui/widgets/test_BaseFileWidget.py
+++ b/test/asammdf/gui/widgets/test_BaseFileWidget.py
@@ -31,21 +31,14 @@ class TestFileWidget(TestBase):
             self.measurement_file = os.path.join(self.resource, "ASAP2_Demo_V171.mf4")
 
     def tearDown(self):
-        _outcome = getattr(self, "_outcome", None)
-        if _outcome:
-            failures = getattr(_outcome.result, "failures", None)
-            for method in _outcome.result.__dir__():
-                if not method.startswith("__"):
-                    print(method, getattr(_outcome.result, method))
-            if failures is not None:
-                # save last state graphical view of widget if failure
-                path = self.screenshots
-                for name in self.id().split(".")[:-1]:
-                    _path = os.path.join(path, name)
-                    if not os.path.exists(_path):
-                        os.makedirs(_path)
-                    path = _path
-                self.widget.grab().save(os.path.join(path, f"{self.id().split('.')[-1]}.png"))
+        # save last state graphical view of widget if failure
+        path = self.screenshots
+        for name in self.id().split(".")[:-1]:
+            _path = os.path.join(path, name)
+            if not os.path.exists(_path):
+                os.makedirs(_path)
+            path = _path
+        self.widget.grab().save(os.path.join(path, f"{self.id().split('.')[-1]}.png"))
 
         if self.widget is not None:
             self.widget.close()


### PR DESCRIPTION
In this PR:
- used HD display (1280x720);
- move gui test `screenshots` folder to the same address as `resources` and `test_workspace`;
- save widget screenshots on `tearDown` from all platforms and python versions
- investigate `self.widget.grab` only if failure, but `pytest._outcome` wraps `unittest._outcome` and for now is not reliable to modify all tests and add `pytest.hookimpl`;
- investigate and repair failed tests. 