### PR TITLE
Align channel metadata behaviour between v3 & v4 blocks

### DIFF
--- a/src/asammdf/blocks/mdf_v3.py
+++ b/src/asammdf/blocks/mdf_v3.py
@@ -2,7 +2,6 @@
 
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
-from copy import deepcopy
 from datetime import datetime
 from functools import lru_cache
 from itertools import product
@@ -2604,7 +2603,6 @@ class MDF3(MDF_Common[Group]):
         grp = self.groups[gp_nr]
 
         channel = grp.channels[ch_nr]
-        channel = deepcopy(channel)
 
         return channel
 


### PR DESCRIPTION
**Issue**

I use the channel.display_names attribute to control channel naming for pandas dataframe output. mdf.to_dataframe(..., use_display_names=True, ...) This is useful for adding device names to channels in case of duplicate channel names from different devices.

With MDFv4.x *.mf4 files, this works fine by changing the display_names attribute in the Channel object and then calling the to_dataframe() method.

However, with MDFv3 *.dat files, the behaviour was different. Even after setting the display_names attribute, the expected display names were not present in the dataframe output. I found that the display_names attribute was cleared whenever the get_channel_metadata() method was re-run while with an MDFv4 file, this was not the case.

``` python
## MDFv4 behaviour ##

from asammdf import MDF

mdf = MDF("some_mdfv4_file.mf4")

meta = mdf.get_channel_metadata("channel", grp, indx)
print(meta.display_names)
>>> {}

meta.display_names = {"test"} # change the display name
print(meta.display_names)
>>> {'test'}

meta = test.mdfObj.get_channel_metadata("channel", grp, indx) # fetch the metadata again
print(meta.display_names)
>>> {'test'}
```

``` python
## MDFv3 behaviour ##

from asammdf import MDF

mdf = MDF("some_mdfv3_file.dat")

meta = mdf.get_channel_metadata("channel", grp, indx)
print(meta.display_names)
>>> {}

meta.display_names = {"test"} # change the display name
print(meta.display_names)
>>> {'test'}

meta = test.mdfObj.get_channel_metadata("channel", grp, indx) # fetch the metadata again
print(meta.display_names)
>>> {}
```

In mdf_v3.py -> MDF3.get_channel_metadata(), a deepcopy of the channel object is made before returning. A copy is not made in mdf_v4.py -> MDF4.get_channel_metadata().


**Fix**

Removed _channel = deepcopy(channel)_ from get_channel_metadata() in mdf_v3.py to align behaviour with mdf_v4.
Also removed associated import of deepcopy which is no longer used.