### PR TITLE
allow to skip tests requiring internet access by defining NO_NET_ACCESS

### DIFF
--- a/src/asammdf/version.py
+++ b/src/asammdf/version.py
@@ -1,3 +1,3 @@
 """asammdf version module"""
 
-__version__ = "8.5.0"
+__version__ = "8.5.1"

--- a/test/asammdf/gui/widgets/batch/test_BatchWidget_Tab_BusLogging.py
+++ b/test/asammdf/gui/widgets/batch/test_BatchWidget_Tab_BusLogging.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 import codecs
+import os
 from pathlib import Path
 import sys
+import unittest
 from unittest import mock
 import urllib
 import urllib.request
@@ -18,6 +20,7 @@ from test.asammdf.gui.widgets.test_BaseBatchWidget import TestBatchWidget
 # to avoid initializing widgets multiple times and consume time.
 
 
+@unittest.skipIf(os.getenv("NO_NET_ACCESS"), "Test requires Internet access")
 class TestPushButtons(TestBatchWidget):
     def setUp(self):
         super().setUp()

--- a/test/asammdf/gui/widgets/batch/test_BatchWidget_Tab_ModifyAndExport.py
+++ b/test/asammdf/gui/widgets/batch/test_BatchWidget_Tab_ModifyAndExport.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import datetime
 from math import ceil
+import os
 from pathlib import Path
 from random import randint
 import unittest
@@ -189,6 +190,7 @@ class TestPushButtonApply(TestBatchWidget):
             for channel in self.selected_channels:
                 self.assertIn(channel, mdf_file.channels_db)
 
+    @unittest.skipIf(os.getenv("NO_NET_ACCESS"), "Test requires Internet access")
     def test_output_format_ASC(self):
         """
         When QThreads are running, event-loops needs to be processed.
@@ -579,6 +581,7 @@ class TestPushButtonApply(TestBatchWidget):
                 self.assertIn(channel, hdf5_channels)
                 np.testing.assert_almost_equal(mdf_channel.samples, hdf5_channel, decimal=3)
 
+    @unittest.skipIf(os.getenv("NO_NET_ACCESS"), "Test requires Internet access")
     def test_output_format_Parquet_0(self):
         """
         When QThreads are running, event-loops needs to be processed.
@@ -621,6 +624,7 @@ class TestPushButtonApply(TestBatchWidget):
                 if np.issubdtype(channel.samples.dtype, np.number):  # problematic conversion
                     np.testing.assert_almost_equal(channel.samples, pandas_tab[name].values, decimal=9)
 
+    @unittest.skipIf(os.getenv("NO_NET_ACCESS"), "Test requires Internet access")
     def test_output_format_Parquet_1(self):
         """
         When QThreads are running, event-loops needs to be processed.

--- a/test/test_CAN_bus_logging.py
+++ b/test/test_CAN_bus_logging.py
@@ -12,6 +12,7 @@ import numpy as np
 from asammdf import MDF
 
 
+@unittest.skipIf(os.getenv("NO_NET_ACCESS"), "Test requires Internet access")
 class TestCANBusLogging(unittest.TestCase):
     tempdir_obd: tempfile.TemporaryDirectory[str]
     tempdir_j1939: tempfile.TemporaryDirectory[str]

--- a/test/test_mdf.py
+++ b/test/test_mdf.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from io import BytesIO
+import os
 from pathlib import Path
 import random
 import tempfile
@@ -25,6 +26,7 @@ SUPPORTED_VERSIONS = tuple(version for version in SUPPORTED_VERSIONS if "4.20" >
 CHANNEL_LEN = 100000
 
 
+@unittest.skipIf(os.getenv("NO_NET_ACCESS"), "Test requires Internet access")
 class TestMDF(unittest.TestCase):
     tempdir_demo: tempfile.TemporaryDirectory[str]
     tempdir_array: tempfile.TemporaryDirectory[str]


### PR DESCRIPTION
This is an adapted version of Sebastien Noël's patch:

https://salsa.debian.org/python-team/packages/asammdf/-/blob/master/debian/patches/skip-tests-internet.patch?ref_type=heads

The current behaviour is retained by default