### PR TITLE
fix: add record-id bytes to calculation of total-size of data-block

### DIFF
--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -636,7 +636,7 @@ class MDF4(MDF_Common[Group]):
                     record_size = channel_group.samples_byte_nr
                 else:
                     total_size += (
-                        channel_group.samples_byte_nr + channel_group.invalidation_bytes_nr
+                        channel_group.samples_byte_nr + channel_group.invalidation_bytes_nr + record_id_nr
                     ) * channel_group.cycles_nr
 
                     record_size = channel_group.samples_byte_nr + channel_group.invalidation_bytes_nr


### PR DESCRIPTION
I encountered problems when i was importing my unsorted mdf4 logfiles. 
There were missing data at the end of the file.

After some investigation i have seen that the calculation of the `total_size` of the datablock resulted in too small byte number, and then the size of the read datablock was too small. When sorting the data then, not all cycles could be filled with data and at the end of the file some data were missing.

The reason of the wrong `total_size` is, that the record-id is not taken into account. 
In sorted datablocks, this is no problem, as the record-id is not used.
But in unsorted datablocks we have a stored record-id in front of each data cycle.
To calculate the correct `total_size`, we have to add the record-id size `record_id_nr`. 
In case of sorted datablocks, `record_id_nr` is 0. So this case also will work.
 
I hope i have found the correct position to add this record-id bytes and did not forget others.
In my tests with my mdf4 files all worked well.