### PR TITLE
fix numpy._core._exceptions._UFuncOutputCastingError in iter_to_dataframe()

### DIFF
--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -8173,7 +8173,7 @@ class MDF4(MDF_Common[Group]):
                 offset = offset // record_size
 
                 vals = arange(len(data_bytes) // record_size, dtype=ch_dtype)
-                vals += offset
+                np.add(vals, offset, out=vals, casting="unsafe")
 
                 if master_is_required:
                     masters.append(


### PR DESCRIPTION
Minimal testcase:
```
from asammdf import MDF

mdf = MDF("input/COOLFILE.MF4")
for df in mdf.iter_to_dataframe():
    print(df.head())
```

Output with asammdf=8.6.10 + numpy=2.3.4:
```
Traceback (most recent call last):
  File "testcase.py", line 4, in <module>
    for df in mdf.iter_to_dataframe():
              ~~~~~~~~~~~~~~~~~~~~~^^
[...]
  File "venv/lib/python3.13/site-packages/asammdf/blocks/mdf_v4.py", line 8189, in _get_scalar
    vals += offset
numpy._core._exceptions._UFuncOutputCastingError: Cannot cast ufunc 'add' output from dtype('float64') to dtype('uint64') with casting rule 'same_kind'
```