### PR TITLE
Fix bus database manager when DBC and/or LIN databases are missing

### DIFF
--- a/src/asammdf/gui/dialogs/bus_database_manager.py
+++ b/src/asammdf/gui/dialogs/bus_database_manager.py
@@ -21,13 +21,13 @@ class BusDatabaseManagerDialog(QtWidgets.QDialog):
 
         databases = {}
 
-        can_databases = self._settings.value("can_databases", [])
+        can_databases = self._settings.value("can_databases", []) or []
         buses = can_databases[::2]
         dbs = can_databases[1::2]
 
         databases["CAN"] = list(zip(buses, dbs, strict=False))
 
-        lin_databases = self._settings.value("lin_databases", [])
+        lin_databases = self._settings.value("lin_databases", []) or []
         buses = lin_databases[::2]
         dbs = lin_databases[1::2]
 

--- a/src/asammdf/gui/widgets/file.py
+++ b/src/asammdf/gui/widgets/file.py
@@ -465,13 +465,13 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
 
         databases = {}
 
-        can_databases = self._settings.value("can_databases", [])
+        can_databases = self._settings.value("can_databases", []) or []
         buses = can_databases[::2]
         dbs = can_databases[1::2]
 
         databases["CAN"] = list(zip(buses, dbs, strict=False))
 
-        lin_databases = self._settings.value("lin_databases", [])
+        lin_databases = self._settings.value("lin_databases", []) or []
         buses = lin_databases[::2]
         dbs = lin_databases[1::2]
 


### PR DESCRIPTION
Using `asammdf` 8.7.2 or master, to reproduce the bug:
 - start the application without config file (e.g. `rm -rf ~/.config/py-asammdf`)
 - go to "Bus database manager"
 - just "Apply" (or load a DBC or LIN but not both)
 - restart application
 - go to "Bus database manager"
 
 ```
 $ uv run asammdf
  File "/home/daniel/asammdf/src/asammdf/gui/widgets/main.py", line 1722, in bus_database_manager
    dlg = BusDatabaseManagerDialog(parent=self)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/daniel/asammdf/src/asammdf/gui/dialogs/bus_database_manager.py", line 25, in __init__
    buses = can_databases[::2]
            ~~~~~~~~~~~~~^^^^^

<class 'TypeError'>: 'NoneType' object is not subscriptable
2025-12-01, 11:16:27
--------------------------------------------------------------------------------
<class 'TypeError'>      
'NoneType' object is not subscriptable
--------------------------------------------------------------------------------
  File "/home/daniel/asammdf/src/asammdf/gui/widgets/main.py", line 1722, in bus_database_manager
    dlg = BusDatabaseManagerDialog(parent=self)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/daniel/asammdf/src/asammdf/gui/dialogs/bus_database_manager.py", line 25, in __init__
    buses = can_databases[::2]
            ~~~~~~~~~~~~~^^^^^
```