### PR TITLE
Fix Qt warnings

### DIFF
--- a/src/asammdf/gui/dialogs/bus_database_manager.py
+++ b/src/asammdf/gui/dialogs/bus_database_manager.py
@@ -37,7 +37,7 @@ class BusDatabaseManagerDialog(QtWidgets.QDialog):
 
         self.verticalLayout.addWidget(self.widget)
 
-        self.horLayout = QtWidgets.QHBoxLayout(self)
+        self.horLayout = QtWidgets.QHBoxLayout()
 
         spacer = QtWidgets.QSpacerItem(
             40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum

--- a/src/asammdf/gui/dialogs/functions_manager.py
+++ b/src/asammdf/gui/dialogs/functions_manager.py
@@ -48,7 +48,7 @@ class FunctionsManagerDialog(QtWidgets.QDialog):
 
         self.verticalLayout.addWidget(self.widget)
 
-        self.horLayout = QtWidgets.QHBoxLayout(self)
+        self.horLayout = QtWidgets.QHBoxLayout()
 
         spacer = QtWidgets.QSpacerItem(
             40, 20, QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Minimum


### PR DESCRIPTION
If we let the `self`, `asammdf` warns on console about:

```
QLayout: Attempting to add QLayout '' to BusDatabaseManagerDialog BusDatabaseManagerDialog, which already has a layout
```