### PR TITLE
Fix inconsistent CAN unknown IDs tracking

### DIFF
--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -10140,7 +10140,7 @@ class MDF4(MDF_Common[Group]):
                                         message = _msg
                                         break
                                 else:
-                                    unknown_ids[msg_id].append(True)
+                                    unknown_ids[(msg_id, is_extended)].append(True)
                                     continue
 
                             is_j1939 = message.is_j1939 or global_is_j1939


### PR DESCRIPTION
In `src/asammdf/blocks/mdf_v4.py`, the `_extract_can_logging` method uses inconsistent keys when tracking unknown CAN message IDs:

- **Line 10134**: When NOT found: `unknown_ids[msg_id].append(True) `- uses `msg_id` (int)
- **Line 10158**: When found: `unknown_ids[(msg_id, is_extended)].append(False) `- uses `(msg_id, is_extended)` (tuple)

This causes a message to have separate dictionary entries for found vs not-found states, breaking the `all(not_found)` check on line 10316.
