### PR TITLE
Fix configuration save with GPS window

### DIFF
--- a/src/asammdf/gui/widgets/gps.py
+++ b/src/asammdf/gui/widgets/gps.py
@@ -91,10 +91,11 @@ class GPS(Ui_GPSDisplay, QtWidgets.QWidget):
         result = []
 
         def callback(*args):
-            result.append(args[0])
+            if args and args[0] is not None and args[0] != '':
+                result.append(args[0])
 
         map_widget = self.map.getMapWidgetAtIndex(self.map.mapWidgetIndex)
-        map_widget.page.runJavaScript("map.getZoom()", self.map.mapWidgetIndex, callback)
+        map_widget.page.runJavaScript("map.getZoom()", callback)
 
         app = QtWidgets.QApplication.instance()
 


### PR DESCRIPTION
The root cause was that `runJavaScript()` was being called with an incorrect number of parameters. The PySide6 `QWebEnginePage.runJavaScript()` signature is:
```python
page.runJavaScript(script, callback)
```
But the code was passing:
```python
page.runJavaScript(script, self.map.mapWidgetIndex,
```
This caused the callback to not be properly registered, leading to result getting an empty string or not being called correctly.
The fix:
 - Removed the `self.map.mapWidgetIndex` parameter
 - Added filtering in the callback to reject None or empty string values

Now it should properly wait for a valid zoom value or timeout and returns the default of 15.
