### PR TITLE
Add name/source filter to channel/filter tree (Natural Sort mode only)

### DIFF
--- a/src/asammdf/gui/ui/file_widget.py
+++ b/src/asammdf/gui/ui/file_widget.py
@@ -69,6 +69,16 @@ class Ui_file_widget(object):
 
         self.channels_layout.addWidget(self.channel_view)
 
+        self.channels_search_name = QLineEdit(self.verticalLayoutWidget)
+        self.channels_search_name.setObjectName(u"channels_search_name")
+        self.channels_search_name.setClearButtonEnabled(True)
+        self.channels_layout.addWidget(self.channels_search_name)
+
+        self.channels_search_bus = QLineEdit(self.verticalLayoutWidget)
+        self.channels_search_bus.setObjectName(u"channels_search_bus")
+        self.channels_search_bus.setClearButtonEnabled(True)
+        self.channels_layout.addWidget(self.channels_search_bus)
+
         self.channels_tree = TreeWidget(self.verticalLayoutWidget)
         self.channels_tree.setObjectName(u"channels_tree")
 
@@ -179,6 +189,16 @@ class Ui_file_widget(object):
         self.filter_view.setObjectName(u"filter_view")
 
         self.verticalLayout_2.addWidget(self.filter_view)
+
+        self.filter_search_name = QLineEdit(self.modify)
+        self.filter_search_name.setObjectName(u"filter_search_name")
+        self.filter_search_name.setClearButtonEnabled(True)
+        self.verticalLayout_2.addWidget(self.filter_search_name)
+
+        self.filter_search_bus = QLineEdit(self.modify)
+        self.filter_search_bus.setObjectName(u"filter_search_bus")
+        self.filter_search_bus.setClearButtonEnabled(True)
+        self.verticalLayout_2.addWidget(self.filter_search_bus)
 
         self.filter_tree = TreeWidget(self.modify)
         self.filter_tree.setObjectName(u"filter_tree")
@@ -1086,6 +1106,8 @@ class Ui_file_widget(object):
         self.channel_view.setItemText(0, QCoreApplication.translate("file_widget", u"Natural sort", None))
         self.channel_view.setItemText(1, QCoreApplication.translate("file_widget", u"Internal file structure", None))
         self.channel_view.setItemText(2, QCoreApplication.translate("file_widget", u"Selected channels only", None))
+        self.channels_search_name.setPlaceholderText(QCoreApplication.translate("file_widget", u"channel pattern", None))
+        self.channels_search_bus.setPlaceholderText(QCoreApplication.translate("file_widget", u"source pattern", None))
 
         ___qtreewidgetitem = self.channels_tree.headerItem()
         ___qtreewidgetitem.setText(0, QCoreApplication.translate("file_widget", u"Channels", None));
@@ -1128,6 +1150,8 @@ class Ui_file_widget(object):
         self.filter_view.setItemText(0, QCoreApplication.translate("file_widget", u"Natural sort", None))
         self.filter_view.setItemText(1, QCoreApplication.translate("file_widget", u"Internal file structure", None))
         self.filter_view.setItemText(2, QCoreApplication.translate("file_widget", u"Selected channels only", None))
+        self.filter_search_name.setPlaceholderText(QCoreApplication.translate("file_widget", u"channel pattern", None))
+        self.filter_search_bus.setPlaceholderText(QCoreApplication.translate("file_widget", u"source pattern", None))
 
         ___qtreewidgetitem1 = self.filter_tree.headerItem()
         ___qtreewidgetitem1.setText(0, QCoreApplication.translate("file_widget", u"Channels", None));

--- a/src/asammdf/gui/ui/file_widget.ui
+++ b/src/asammdf/gui/ui/file_widget.ui
@@ -109,6 +109,26 @@
             </widget>
            </item>
            <item>
+            <widget class="QLineEdit" name="channels_search_name">
+             <property name="placeholderText">
+              <string>channel pattern</string>
+             </property>
+             <property name="clearButtonEnabled">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="channels_search_bus">
+             <property name="placeholderText">
+              <string>source pattern</string>
+             </property>
+             <property name="clearButtonEnabled">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="TreeWidget" name="channels_tree">
              <property name="toolTip">
               <string>Double click channel to see extended information</string>
@@ -337,6 +357,26 @@
             </property>
            </item>
           </widget>
+         </item>
+         <item>
+         <widget class="QLineEdit" name="filter_search_name">
+           <property name="placeholderText">
+           <string>channel pattern</string>
+           </property>
+           <property name="clearButtonEnabled">
+           <bool>true</bool>
+           </property>
+         </widget>
+         </item>
+         <item>
+         <widget class="QLineEdit" name="filter_search_bus">
+           <property name="placeholderText">
+           <string>source pattern</string>
+           </property>
+           <property name="clearButtonEnabled">
+           <bool>true</bool>
+           </property>
+         </widget>
          </item>
          <item>
           <widget class="TreeWidget" name="filter_tree">

--- a/src/asammdf/gui/widgets/file.py
+++ b/src/asammdf/gui/widgets/file.py
@@ -309,7 +309,24 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
             self.mdi_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarPolicy.ScrollBarAsNeeded)
             self.splitter.addWidget(self.mdi_area)
 
+            self.channel_search_update_timer = QtCore.QTimer(self)
+            self.channel_search_update_timer.setSingleShot(True)
+            self.channel_search_update_timer.setInterval(200) # ms delay
+            self.channel_search_update_timer.timeout.connect(partial(self._update_inline_search, widget=self.channels_tree))
+            self.channels_search_name.textChanged.connect(self.channel_search_update_timer.start)
+            self.channels_search_name.pattern = None
+            self.channels_search_bus.textChanged.connect(self.channel_search_update_timer.start)
+            self.channels_search_bus.pattern = None
             self.channels_tree.itemDoubleClicked.connect(self.show_info)
+
+            self.filter_search_update_timer = QtCore.QTimer(self)
+            self.filter_search_update_timer.setSingleShot(True)
+            self.filter_search_update_timer.setInterval(200) # ms delay
+            self.filter_search_update_timer.timeout.connect(partial(self._update_inline_search, widget=self.filter_tree))
+            self.filter_search_name.textChanged.connect(self.filter_search_update_timer.start)
+            self.filter_search_name.pattern = None
+            self.filter_search_bus.textChanged.connect(self.filter_search_update_timer.start)
+            self.filter_search_bus.pattern = None
             self.filter_tree.itemDoubleClicked.connect(self.show_info)
 
             self.channel_view.setCurrentIndex(-1)
@@ -534,6 +551,49 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
         for widget in widgetList:
             self._update_channel_tree(widget=widget)
 
+    def _update_inline_search(self, widget=None):
+        # Move all regex logic here
+        # Mark search bar as red if regex is not valid
+        # If both are valid, then parse and call _update_channel_tree
+        if widget is self.channels_tree:
+            search_name = self.channels_search_name
+            search_bus = self.channels_search_bus
+        else:
+            search_name = self.filter_search_name
+            search_bus = self.filter_search_bus
+        do_update = True
+
+        valid_text_color = QtGui.QPalette()
+        valid_text_color.setColor(QtGui.QPalette.Text, QtCore.Qt.white)
+        error_text_color = QtGui.QPalette()
+        error_text_color.setColor(QtGui.QPalette.Text, QtCore.Qt.red)
+        try:
+            name_pattern = ".*" + search_name.text().strip() + ".*"
+            if name_pattern.islower():
+                name_pattern = re.compile(name_pattern, re.IGNORECASE)
+            else:
+                name_pattern = re.compile(name_pattern)
+            search_name.pattern = name_pattern
+            search_name.setPalette(valid_text_color)
+        except re.error:
+            search_name.setPalette(error_text_color)
+            do_update = False
+
+        try:
+            bus_pattern = ".*" + search_bus.text().strip() + ".*"
+            if bus_pattern.islower():
+                bus_pattern = re.compile(bus_pattern, re.IGNORECASE)
+            else:
+                bus_pattern = re.compile(bus_pattern)
+            search_bus.pattern = bus_pattern
+            search_bus.setPalette(valid_text_color)
+        except re.error:
+            search_bus.setPalette(error_text_color)
+            do_update = False
+
+        if do_update:
+            self._update_channel_tree(widget=widget)
+
     def _update_channel_tree(self, index=None, widget=None, force=False):
         if widget is None:
             widget = self.channels_tree
@@ -544,6 +604,8 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
                 return
 
         view = self.channel_view if widget is self.channels_tree else self.filter_view
+        search_name = self.channels_search_name if widget is self.channels_tree else self.filter_search_name
+        search_bus = self.channels_search_bus if widget is self.channels_tree else self.filter_search_bus
 
         iterator = QtWidgets.QTreeWidgetItemIterator(widget)
         signals = set()
@@ -567,12 +629,24 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
         widget.mode = view.currentText()
 
         if widget.mode == "Natural sort":
+            search_name.setVisible(True)
+            search_bus.setVisible(True)
+
             items = []
             for i, group in enumerate(self.mdf.groups):
                 for j, ch in enumerate(group.channels):
                     entry = i, j
 
-                    channel = MinimalTreeItem(entry, ch.name, strings=[ch.name], origin_uuid=self.uuid)
+                    # Limit search to 10k items and apply search filters
+                    if len(items) >= 10_000:
+                        break
+                    if search_name.pattern and not search_name.pattern.search(ch.name):
+                        continue
+                    bus = group.channel_group.acq_source.path or "None"
+                    if search_bus.pattern and not search_bus.pattern.search(bus):
+                        continue
+
+                    channel = MinimalTreeItem(entry, ch.name, strings=[f"{ch.name} —— {bus:<10}"], origin_uuid=self.uuid)
                     channel.setToolTip(0, f"{ch.name} @ group {i}, index {j}")
 
                     if entry in signals:
@@ -589,8 +663,10 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
             widget.addTopLevelItems(items)
 
         elif widget.mode == "Internal file structure":
-            items = []
+            search_name.setVisible(False)
+            search_bus.setVisible(False)
 
+            items = []
             for i, group in enumerate(self.mdf.groups):
                 entry = i, 0xFFFFFFFFFFFFFFFF
 
@@ -663,6 +739,10 @@ class FileWidget(WithMDIArea, Ui_file_widget, QtWidgets.QWidget):
             widget.addTopLevelItems(items)
 
         else:
+            # widget.mode == "Selected channels only"
+            search_name.setVisible(False)
+            search_bus.setVisible(False)
+
             items = []
             for entry in signals:
                 gp_index, ch_index = entry
@@ -1663,7 +1743,7 @@ MultiRasterSeparator;&
 
             if windows:
                 unsaved = False
-                
+
                 if hexdigest:
                     worker = md5()
                     try:


### PR DESCRIPTION
Still work-in-progress, but most of the content is up and I think ready for discussion.

- Adds new user input boxes for specifying a smart-case regex search pattern for signal names / sources in the "Channels" and "Modify & Export" views.
  - I added the filters to "Modify & Export" for consistency, but I personally don't care because I don't use that workflow.
- Limits tree size to 10k signals. Profiling showed that it would take ~1-2 seconds to _clear_ the widget of all signals (for very large traces of course). Subsequent updates are fast, since the widget only needs to clear the previously filtered signals.
- Adds the "path" / "source" to the signal name to assist in differentiating between signals with the same name. Perhaps this should be updated to be the group name?

WIP:
- add some tests
- move 10k signal limit to user configuration files?
- add key-bind (I like Alt-F) to move focus to the search bar
- come up with a better solution for displaying a signal's path

Example Images:
<img width="536" height="391" alt="image" src="https://github.com/user-attachments/assets/589cec42-ed8e-4069-b23d-697e49680e7d" />
<img width="526" height="369" alt="image" src="https://github.com/user-attachments/assets/13c9041e-f08d-4833-a41d-956703dde0d1" />

