### PR TITLE
fix: handle None channel comment when encoding metadata

### DIFF
--- a/src/asammdf/blocks/v4_blocks.py
+++ b/src/asammdf/blocks/v4_blocks.py
@@ -1329,7 +1329,7 @@ class Channel:
                 else:
                     text = comment
         else:
-            text = comment
+            text = comment or ""
 
         if text in defined_texts:
             self.comment_addr = defined_texts[text]


### PR DESCRIPTION
When a channel has no display names and its `comment` is `None`, the final branch sets `text = comment`, leaving `text` as `None`. The subsequent `text.startswith("<CN")` then raises an error (`'NoneType' object has no attribute 'startswith'`) during block encoding.

This change defaults the comment to an empty string in that branch (`text = comment or ""`), matching the behavior of the other branches that already produce a valid string. There is no functional change for non-`None` comments.

### Before
```python
text = comment
```

### After
```python
text = comment or ""
```
