### PR TITLE
fix: handle None channel comment when encoding metadata

### DIFF
--- a/src/asammdf/blocks/v4_blocks.py
+++ b/src/asammdf/blocks/v4_blocks.py
@@ -1329,7 +1329,7 @@ class Channel:
                 else:
                     text = comment
         else:
-            text = comment
+            text = comment or ""
 
         if text in defined_texts:
             self.comment_addr = defined_texts[text]


### PR DESCRIPTION
﻿This ports the fix from #1296 to master.

Original change:
- src/asammdf/blocks/v4_blocks.py
- text = comment -> text = comment or ""

Reason:
PR #1296 was merged into development; this brings the same fix into master.
