### PR TITLE
build: pin CMake to <4 to fix the Windows wheel build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,10 @@ Issues = "https://github.com/danielhrisca/asammdf/issues"
 Source = "https://github.com/danielhrisca/asammdf"
 
 [tool.scikit-build]
-cmake.version = ">=3.26,<4.2"
+# CMake 4.x selects the "NMake Makefiles" generator on the Windows runners and
+# fails to locate a C compiler ("CMAKE_C_COMPILER not set"), breaking the wheel
+# build. Pin to 3.x until the generator selection is fixed upstream.
+cmake.version = ">=3.26,<4"
 metadata.version.provider = "scikit_build_core.metadata.regex"
 metadata.version.input = "src/asammdf/version.py"
 sdist.include = ["ext"]


### PR DESCRIPTION
## Problem

`pyinstaller_build`, `wheels`, and the Windows jobs of `tests` all fail
during the wheel build on `windows-latest`:

```
-- Building for: NMake Makefiles
CMake Error at CMakeLists.txt:2 (project):
  Running 'nmake' '-?' failed with: no such file or directory
CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
```

CMake 4.x selects the *NMake Makefiles* generator on the Windows runners
instead of the Visual Studio generator, and then fails to locate a C
compiler. Only Windows is affected — macOS and Linux build fine with the
same CMake 4.1.3.

The Windows build was green through 2026-06-12 and started failing on
2026-06-15, when CMake 4.x began being installed (the existing `<4.2`
bound allowed it).

## Fix

Pin `cmake.version` to `<4` so scikit-build-core uses CMake 3.x again,
whose default Windows generator is Visual Studio and correctly locates
the MSVC toolchain.

Verified locally: the constraint resolves to CMake 3.31.10 and the
extension modules still build.

https://claude.ai/code/session_015hnxFTuXjNWSp7A4BJ3t1p
