### PR TITLE
fix: VLSD signal data is unreadable after a composed channel

### DIFF
--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -1065,7 +1065,6 @@ class MDF4(MDF_Common[Group]):
 
                 index = ch_cntr - 1
                 dependencies.append(None)
-                grp.signal_data.append(None)
 
                 # check if it is a CABLOCK or CNBLOCK
                 stream.seek(component_addr)

--- a/test/test_mdf4.py
+++ b/test/test_mdf4.py
@@ -189,6 +189,35 @@ class TestMDF4(unittest.TestCase):
 
         self.assertTrue((record == signal.samples).all())
 
+    def test_vlsd_channel_after_structure_composition(self) -> None:
+        """A VLSD channel that sits after a structure (composed) channel in the
+        same group must still find its signal data.
+
+        ``Group.signal_data`` is indexed by channel index, so an extra entry
+        pushed for a composed channel shifts every following channel's VLSD
+        block info and makes the payload unreadable.
+        """
+        count = 20
+        timestamps = np.arange(count, dtype="<f8")
+
+        record = np.rec.fromarrays(
+            [np.arange(count, dtype="<u2"), np.arange(count, dtype="<u1") % 5],
+            dtype=np.dtype([("a", "<u2"), ("b", "<u1")]),
+        )
+        structure = Signal(record, timestamps=timestamps, name="Structure")
+        texts = np.array([("x" * (i % 5 + 1)).encode("latin-1") for i in range(count)], dtype="S8")
+        text = Signal(texts, timestamps=timestamps, name="Text", encoding="latin-1")
+
+        path = Path(TestMDF4.tempdir.name) / "vlsd_after_structure.mf4"
+        with MDF(version="4.10") as mdf:
+            mdf.append([structure, text])
+            mdf.save(path, overwrite=True)
+
+        with MDF(path) as mdf:
+            group = mdf.groups[0]
+            self.assertEqual(len(group.signal_data), len(group.channels))
+            self.assertTrue(np.array_equal(mdf.get("Text", group=0).samples, texts))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Background — what VLSD is

Most MDF4 channels are fixed-width columns inside the record: the channel says
"my value lives at byte offset 12, 2 bytes wide", and every sample is the same
size. Some data cannot work that way — a text channel, or a CAN-FD payload whose
length changes from frame to frame. MDF4 stores those **out of line**: the record
holds only a 64-bit offset, and the actual bytes sit in separate signal-data
blocks elsewhere in the file. Such a channel is a **VLSD** channel — *variable
length signal data*.

To read one, asammdf has to know where that channel's signal-data blocks are.
It collects them per group in `Group.signal_data`, a plain list **indexed by
channel index**, filled while the channel list is parsed. If that list ever falls
out of step with `Group.channels`, a VLSD channel looks up somebody else's blocks
— or none at all.

That is what happens here.

## Problem

`MDF4._read_channels` appends an **extra** `grp.signal_data.append(None)` for
every channel that has a `component_addr` (a structure or array composition),
while `dependencies` gets exactly one entry per channel.

So every composed channel shifts the signal-data entry of all following channels
by one, and `_load_signal_data` then looks in the wrong slot. Reading such a
channel raises:

```
MdfException: Wrong signal data block refence (0x4AD5260) for VLSD channel "CAN_DataFrame.DataBytes"
```

## Impact

This affects every CAN-FD bus-logging measurement recorded with variable-length
payloads — which is the normal case, since a CAN-FD frame carries anywhere from
0 to 64 bytes. `CAN_DataFrame.DataBytes` is a VLSD channel, and it lives inside
the composed `CAN_DataFrame` structure, so it is always one of the shifted ones.
`MDF.extract_bus_logging()` cannot read the payload at all and the file is
effectively unusable.

Found on two real OEM CAN-FD bus logs (1.0 GB and 157 MB, 5.1 M and 2.3 M CAN
frames); with the fix both extract normally.

## Fix

Drop the stray append. `grp.signal_data` then stays in step with `grp.channels`.

## Test

`test_vlsd_channel_after_structure_composition` in `test/test_mdf4.py` — writes a
VLSD (string) channel after a structure channel in the same group, then reads it
back. Fully offline, no downloads.

Without the fix:

```
AssertionError: 6 != 5                                     # len(signal_data) vs len(channels)
MdfException: Wrong signal data block refence (0x7D0) ...   # reading the channel
```

`test_mdf`, `test_mdf4`, `test_CAN_bus_logging`, `test_endianess`, `test_cantp`
and `test_signal` all pass.
