### PR TITLE
Fix AttributeError reading LDBLOCK (self.self typo) and column-oriented append crash

### DIFF
--- a/src/asammdf/blocks/mdf_v4.py
+++ b/src/asammdf/blocks/mdf_v4.py
@@ -4405,10 +4405,6 @@ class MDF4(MDF_Common[Group]):
 
             gp_sig_types.append(sig_type)
 
-            axes = signal.axes or {}
-            conversions = signal.conversions or {}
-            units = signal.units or {}
-
             # first add the signals in the simple signal list
             if sig_type == v4c.SIGNAL_TYPE_SCALAR:
                 # compute additional byte offset for large records size

--- a/src/asammdf/blocks/v4_blocks.py
+++ b/src/asammdf/blocks/v4_blocks.py
@@ -6900,7 +6900,7 @@ class ListData(_ListDataBase):
 
                 address += self.links_nr * 8
 
-                self.flags, self.zip_info, self.zip_info_inval, self.flags_ext, self.self.data_block_nr = unpack_from(
+                self.flags, self.zip_info, self.zip_info_inval, self.flags_ext, self.data_block_nr = unpack_from(
                     "<4BI", stream, address
                 )
                 address += 8
@@ -6964,7 +6964,7 @@ class ListData(_ListDataBase):
 
                 links = unpack(f"<{self.links_nr}Q", stream.read(self.links_nr * 8))
 
-                self.flags, self.zip_info, self.zip_info_inval, self.flags_ext, self.self.data_block_nr = typing.cast(
+                self.flags, self.zip_info, self.zip_info_inval, self.flags_ext, self.data_block_nr = typing.cast(
                     tuple[int, int], unpack("<4BI", stream.read(8))
                 )
 

--- a/test/test_mdf4.py
+++ b/test/test_mdf4.py
@@ -83,6 +83,49 @@ class TestMDF4(unittest.TestCase):
         self.assertTrue(np.array_equal(ret_sig_int.samples, sig_int.samples))
         self.assertTrue(np.array_equal(ret_sig_float.samples, sig_float.samples))
 
+    def test_read_mdf4_20_column_storage(self) -> None:
+        # regression test: 4.20 column storage wraps data in LDBLOCKs, whose
+        # parsing raised AttributeError ('ListData' object has no attribute 'self')
+        seed = np.random.randint(0, 2**31)
+
+        np.random.seed(seed)
+        print("Read 4.20 using seed =", seed)
+
+        sig_int = Signal(
+            np.random.randint(-(2**31), 2**31, CHANNEL_LEN),
+            np.arange(CHANNEL_LEN),
+            name="Integer Channel",
+            unit="unit1",
+        )
+
+        sig_float = Signal(
+            np.random.random(CHANNEL_LEN),
+            np.arange(CHANNEL_LEN),
+            name="Float Channel",
+            unit="unit2",
+        )
+
+        with MDF(version="4.20") as mdf:
+            mdf.append([sig_int], common_timebase=True)
+            outfile = mdf.save(Path(TestMDF4.tempdir.name) / "tmp", overwrite=True)
+
+        # column storage (and therefore LDBLOCK output) only engages for
+        # column-oriented groups, appended when the file was opened with
+        # column_storage=True
+        with MDF(outfile, column_storage=True) as mdf:
+            mdf.append([sig_float], common_timebase=True)
+            outfile = mdf.save(Path(TestMDF4.tempdir.name) / "tmp_ld", overwrite=True)
+
+        with open(outfile, "rb") as ld_stream:
+            self.assertIn(b"##LD", ld_stream.read())
+
+        with MDF(outfile) as mdf:
+            ret_sig_int = mdf.get(sig_int.name)
+            ret_sig_float = mdf.get(sig_float.name)
+
+        self.assertTrue(np.array_equal(ret_sig_int.samples, sig_int.samples))
+        self.assertTrue(np.array_equal(ret_sig_float.samples, sig_float.samples))
+
     def test_attachment_blocks_wo_filename(self) -> None:
         original_data = b"Testing attachemnt block\nTest line 1"
         mdf = MDF()


### PR DESCRIPTION
**Affected:** `master` (`v4_blocks.py:6903` mapped branch, `:6967` stream branch); present since at least 8.8.18.

`ListData.__init__` unpacks the LDBLOCK data section into `self.self.data_block_nr` instead of `self.data_block_nr` — in both the mapped and the stream branch. `ListData` has no attribute `self`, so evaluating `self.self` raises `AttributeError` before the assignment happens. Since `ListData` is constructed for every `##LD` block encountered while loading data, any MDF 4.2 file that stores column-oriented data behind an LDBLOCK fails to open.

While writing the regression test we found the matching write path is also broken: `_append_column_oriented` — the path that produces `##LD` output, engaged by appending to a file opened with `column_storage=True` — reads `signal.axes` / `signal.conversions` / `signal.units`, none of which exist on `Signal`, and crashes on the first appended signal. The three locals are never used, so the lines are simply removed.

**Reproduction** (current master):

```python
from asammdf import MDF, Signal
import numpy as np

sig = Signal(np.arange(10, dtype=np.float64), np.arange(10, dtype=np.float64), name="x")
with MDF(version="4.20") as m:
    m.append(sig)
    m.save("plain.mf4", overwrite=True)

# column storage (##LD output) only engages for groups appended
# after opening with column_storage=True
with MDF("plain.mf4", column_storage=True) as m:
    m.append(Signal(np.arange(10, dtype=np.float64), np.arange(10, dtype=np.float64), name="y"))
    m.save("ld.mf4", overwrite=True)
    # before this PR: AttributeError: 'Signal' object has no attribute 'axes'

MDF("ld.mf4").get("y")
# before this PR: AttributeError: 'ListData' object has no attribute 'self'
```

**Changes**

- `v4_blocks.py`: `self.self.data_block_nr` → `self.data_block_nr` in both branches of `ListData.__init__`
- `mdf_v4.py`: remove the three unused `signal.axes` / `signal.conversions` / `signal.units` locals from `_append_column_oriented`
- `test/test_mdf4.py`: `test_read_mdf4_20_column_storage` — writes a 4.20 file, reopens it with `column_storage=True`, appends a second signal (column-oriented, wrapped in `##LD` — the test asserts the bytes are really there), reads both signals back and compares samples

The new test fails with the `ListData` `AttributeError` before the fix and passes after; the rest of `test_mdf4.py` stays green.
