### PR TITLE
fix: unblock test collection and Windows pyinstaller build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,22 @@ jobs:
           libxcb-icccm4 libxcb-image0 libxcb-cursor0 libxcb-keysyms1 libxcb-xkb1 libxcb-shape0 \
           libxkbcommon-x11-0 libxcb-render-util0
 
+      - name: Install Ninja (Windows)
+        if: runner.os == 'Windows'
+        run: choco install ninja -y
+
+      - name: Install Visual Studio Build Tools (Windows)
+        if: runner.os == 'Windows'
+        run: choco install visualstudio2022-workload-vctools -y
+
       - name: Install Python packages
         run: |
           pip install tox
 
       - name: Build the executable
+        shell: bash
+        env:
+          CMAKE_GENERATOR: "Ninja"
         run: |
           tox -e pyinstaller -- --distpath dist/${{ matrix.os }} --noconfirm --clean
 

--- a/test/asammdf/gui/widgets/Shortcuts/test_Tabular_BaseWidget_Shortcuts.py
+++ b/test/asammdf/gui/widgets/Shortcuts/test_Tabular_BaseWidget_Shortcuts.py
@@ -47,7 +47,7 @@ class TestDataTableViewShortcuts(TestFileWidget):
         self.assertIsNotNone(self.load_shortcuts_from_json_file(self.dtw))
         self.processEvents(0.01)
 
-    @skipIf(sys.platform == "linux")
+    @skipIf(sys.platform == "linux", "not supported on Linux yet")
     def test_set_color_range_shortcut(self):
         """
             Test Scope:


### PR DESCRIPTION
## Two small, independent CI fixes

### 1. `tests` collecting nothing on any platform

`test_Tabular_BaseWidget_Shortcuts.py:50` calls `@skipIf(sys.platform == "linux")`
without the required `reason` argument:

```
TypeError: skipIf() missing 1 required positional argument: 'reason'
```

That's raised at import time, which aborts collection for the *entire* suite —
not just this file — on every OS. Add the missing reason string.

### 2. `pyinstaller_build` still red on Windows

Same root cause #1306 diagnosed: CMake 4.x picks the "NMake Makefiles"
generator on `windows-latest` and fails with `CMAKE_C_COMPILER not set`.
`wheels.yml` already got fixed for this (0435fa1c) by forcing the Ninja
generator instead of downgrading CMake, but `build.yml` (the workflow behind
the `pyinstaller_build` check) never got the same treatment. This mirrors
that fix: install Ninja + VS Build Tools on Windows, force
`CMAKE_GENERATOR=Ninja`.

## Testing

Both verified locally before opening this, not just by reasoning about it:

- Reproduced the collection error locally, fixed it, then collected the full
  suite: 228 items, 0 errors (was 1 error aborting collection entirely).
- Rebuilt the C extension locally with `CMAKE_GENERATOR=Ninja` forced (same
  env var `build.yml` now sets) — `scikit-build-core` confirms `Building
  project with Ninja...`, the extension imports, and the full non-GUI suite
  passes against that rebuild (56 passed, 2 skipped).
- Can't exercise the Windows-specific compiler-discovery path from this
  machine, but it's the identical mechanism already proven green on
  `windows-latest` in `wheels.yml`'s own CI runs.